### PR TITLE
Fix hardcoded path to /bin/bash -> /usr/bin/env bash

### DIFF
--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 
 if [ -z "$INSTALL_PATH" ]; then


### PR DESCRIPTION
The path /bin/bash is not guaranteed to exist on a Posix system, but /usr/bin/env is.

Signed-off-by: Henner Zeller <h.zeller@acm.org>