### PR TITLE
formal_verification: Print out the error in case of equiv subprocess …

### DIFF
--- a/formal_verification.py
+++ b/formal_verification.py
@@ -263,6 +263,9 @@ def run_equiv(top_module, output_dir):
         capture_output=True,
         text=True,
     )
+    if process.returncode:
+        print("Subprocess [ %s ] returned error:" % (subprocess.list2cmdline(process.args)))
+        print(process.stderr)
 
     return process
 


### PR DESCRIPTION
Possible failure of subprocess running yosys inside _run_equiv()_ was not visible to the user, and it was possible for the next steps that required its output to be performed despite its failure. In some cases it leaded to script failure, not showing the reason for it. For example, there was a case in which `/usr/bin/time` binary was missing and that caused the script to fail but only after running _get_equiv_result()_, complaining about missing _equiv.out_ file, which was the output of the subprocess that failed to start.
After this modification, the error from the subprocess is printed out right away, if occurred.