### PR TITLE
Add manual CI trigger.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,20 @@
 name: 'main'
+run-name: >
+  ${{ github.event_name == 'workflow_dispatch' &&
+        format('{0}{1}',
+          github.ref_name,
+          (github.event.inputs.plugins_branch && format('; plugins: {0}', github.event.inputs.plugins_branch) || '')
+        )
+      || ''
+  }}
 
 on:
+  workflow_dispatch:
+    inputs:
+      plugins_branch:
+        description: 'yosys-symbiflow-plugins branch'
+        required: false
+        default: ''
   push:
     branches:
       - master
@@ -43,6 +57,14 @@ jobs:
       uses: nanzm/get-time-action@v1.1
       with:
         format: 'YYYY-MM-DD-HH-mm-ss'
+
+    - name: Checkout custom branches in submodules (if requested)
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.plugins_branch != ''}}
+      run: |
+        cd yosys-symbiflow-plugins
+        git remote add github/antmicro https://github.com/antmicro/yosys-f4pga-plugins.git
+        git fetch github/antmicro ${{github.event.inputs.plugins_branch}}
+        git checkout FETCH_HEAD
 
     - name: Setup cache
       uses: actions/cache@v2

--- a/README.rst
+++ b/README.rst
@@ -155,6 +155,56 @@ To parse a multi-file with the ``read_systemverilog`` command, all files have to
     # Continue Yosys flow...
     exit
 
+Testing in CI/Github Actions
+----------------------------
+
+Using dedicated branch
+^^^^^^^^^^^^^^^^^^^^^^
+
+Create a new branch and point submodules to revisions with your changes. Then pick one of the following methods.
+
+Create a Pull Request
+"""""""""""""""""""""
+
+Just that. Create a (WIP) Pull Request using your new branch.
+
+Start a workflow manually (using Github Web UI)
+"""""""""""""""""""""""""""""""""""""""""""""""
+
+In Github Web UI, on the repository page:
+
+- Open the "Actions" tab.
+- Select "main" on the Actions list on the left.
+- At the top of the workflows list click the "Run workflow" button.
+- Select your branch in the "Use workflow from" dropdown.
+- Click the "Run workflow" button.
+
+Start a workflow manually (using Github CLI)
+""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+   :name: gh-cli-start-workflow
+
+   gh workflow run main --ref $YOUR_BRANCH_NAME
+
+Using plugins submodule override
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This method can be used to test changes limited to `yosys-symbiflow-plugins` submodule.
+
+- Push your changes in `yosys-symbiflow-plugins` into a branch in https://github.com/antmicro/yosys-f4pga-plugins/
+- Perform steps from "Start a workflow manually (using Github Web UI)" above, but:
+
+  - Select "master" (or any other branch with submodule revisions you would like to use in the CI) in the "Use workflow from" dropdown.
+  - In the same pop-up, under "yosys-symbiflow-plugins branch", type the name of the branch from https://github.com/antmicro/yosys-f4pga-plugins/. This branch will be checked out in `yosys-symbiflow-plugins` submodule.
+
+- Alternatively, use Github CLI:
+
+  .. code-block:: bash
+     :name: gh-cli-start-workflow-with-plugins-branch
+
+     gh workflow run main --ref master -f plugins_branch=$PLUGINS_BRANCH_NAME
+
 General & debugging tips
 ------------------------
 


### PR DESCRIPTION
Adds `workflow_dispatch` trigger, with optional `plugins_branch` parameter (AKA input).

This will allow privileged users to start a workflow manually (through github web UI or gh cli tool) on any branch of this repo. Additionally, by specifying `plugins_branch` (again, in UI or gh cli) to a branch present in https://github.com/antmicro/yosys-f4pga-plugins/, it is possible to override revision of `yosys-symbiflow-plugins`. This way one can push a branch to `yosys-f4pga-plugins` and be able to test it in a workflow in `yosys-systemverilog` without creating a branch there.

Manually started tasks use custom titles on actions list:

![ci](https://user-images.githubusercontent.com/4888536/201097082-b97ba7ed-2cc9-4571-87e5-d113ab761fa8.png)

In order, from top to bottom:

- started manually without setting `plugins_branch` using command:
  `gh workflow run main --ref mglb/AddManualCITrigger`
- started manually with `plugins_branch=mglb/DeferTypedefSimplification` using command:
  `gh workflow run main --ref mglb/AddManualCITrigger -f plugins_branch=mglb/DeferTypedefSimplification`
- started by `pull_request` event (default title)

The web UI for this will appear only after the merge. This will look like this:
![ui](https://i0.wp.com/user-images.githubusercontent.com/1865328/86147571-2de93700-babf-11ea-8a08-e4beffd3abe9.png?ssl=1)