### PR TITLE
Optimize CI

### DIFF
--- a/.github/scripts/generate_summary.sh
+++ b/.github/scripts/generate_summary.sh
@@ -1,0 +1,96 @@
+ROOT_DIR=$(dirname $(dirname $(dirname "$0")))
+TEST_RESULTS_PREFIX=$ROOT_DIR/test-results
+UHDM_PASSED_FILE=$TEST_RESULTS_PREFIX-uhdm.passed
+UHDM_FAILED_FILE=$TEST_RESULTS_PREFIX-uhdm.failed
+SYSTEMVERILOG_PASSED_FILE=$TEST_RESULTS_PREFIX-systemverilog.passed
+SYSTEMVERILOG_FAILED_FILE=$TEST_RESULTS_PREFIX-systemverilog.failed
+VCDDIFF_PASSED_FILE=$TEST_RESULTS_PREFIX-vcddiff.passed
+VCDDIFF_FAILED_FILE=$TEST_RESULTS_PREFIX-vcddiff.failed
+
+# Read passed tests if any exist
+if [[ -e $UHDM_PASSED_FILE ]]; then
+    UHDM_PASSED_NUMBER=$(wc -l $UHDM_PASSED_FILE)
+else
+    UHDM_FAILED_NUMBER=0
+fi
+if [[ -e $SYSTEMVERILOG_PASSED_FILE ]]; then
+    SYSTEMVERILOG_PASSED_NUMBER=$(wc -l $SYSTEMVERILOG_PASSED_FILE)
+else
+    SYSTEMVERILOG_PASSED_NUMBER=0
+fi
+if [[ -e $VCDDIFF_PASSED_FILE ]]; then
+    VCDDIFF_PASSED_NUMBER=$(wc -l $VCDDIFF_PASSED_FILE)
+else
+    VCDDIFF_PASSED_NUMBER=0
+fi
+
+# Read failed tests if any exist
+if [[ -e $UHDM_FAILED_FILE ]]; then
+    UHDM_FAILED_NUMBER=$(wc -l $UHDM_FAILED_FILE)
+else
+    UHDM_FAILED_NUMBER=0
+fi
+if [[ -e $SYSTEMVERILOG_FAILED_FILE ]]; then
+    SYSTEMVERILOG_FAILED_NUMBER=$(wc -l $SYSTEMVERILOG_FAILED_FILE)
+else
+    SYSTEMVERILOG_FAILED_NUMBER=0
+fi
+if [[ -e $VCDDIFF_FAILED_FILE ]]; then
+    VCDDIFF_FAILED_NUMBER=$(wc -l $VCDDIFF_FAILED_FILE)
+else
+    VCDDIFF_FAILED_NUMBER=0
+fi
+
+TOTAL_FAILED_TESTS=$(($UHDM_FAILED_NUMBER+$SYSTEMVERILOG_FAILED_NUMBER+$VCDDIFF_FAILED_NUMBER))
+TOTAL_PASSED_TESTS=$(($UHDM_PASSED_NUMBER+$SYSTEMVERILOG_PASSED_NUMBER+$VCDDIFF_PASSED_NUMBER))
+TOTAL_TESTS=$(($TOTAL_FAILED_TESTS+$TOTAL_PASSED_TESTS))
+
+if [[ ! -e $UHDM_FAILED_FILE && ! -e $SYSTEMVERILOG_FAILED_FILE && ! -e $VCDDIFF_FAILED_FILE ]]; then
+    echo ":heavy_check_mark: ALL TESTS PASSED :heavy_check_mark:" > $GITHUB_STEP_SUMMARY
+else
+    echo ":x: SOME TESTS FAILED :x:" > $GITHUB_STEP_SUMMARY
+fi
+echo "" >> $GITHUB_STEP_SUMMARY
+echo "| Name | Tests failed |" >> $GITHUB_STEP_SUMMARY
+echo "|------|--------------|" >> $GITHUB_STEP_SUMMARY
+echo "| tests-read-uhdm          | $UHDM_FAILED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| tests-read-systemverilog | $SYSTEMVERILOG_FAILED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| tests-read-vcddiff       | $VCDDIFF_FAILED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| **Total** | **$TOTAL_FAILED_TESTS** |" >> $GITHUB_STEP_SUMMARY
+echo "" >> $GITHUB_STEP_SUMMARY
+echo "$TOTAL_FAILED_TESTS out of total $TOTAL_TESTS failed." >> $GITHUB_STEP_SUMMARY
+echo "" >> $GITHUB_STEP_SUMMARY
+echo "" >> $GITHUB_STEP_SUMMARY
+
+echo "# Results for tests-read-uhdm:" >> $GITHUB_STEP_SUMMARY
+echo "| Name | Result |" >> $GITHUB_STEP_SUMMARY
+echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+while IFS= read -r LINE; do
+    echo "$LINE" >> $GITHUB_STEP_SUMMARY
+done < $UHDM_FAILED_FILE
+while IFS= read -r LINE; do
+    echo "$LINE" >> $GITHUB_STEP_SUMMARY
+done < $UHDM_PASSED_FILE
+echo "" >> $GITHUB_STEP_SUMMARY
+
+echo "# Results for tests-read-systemverilog:" >> $GITHUB_STEP_SUMMARY
+echo "| Name | Result |" >> $GITHUB_STEP_SUMMARY
+echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+while IFS= read -r LINE; do
+    echo "$LINE" >> $GITHUB_STEP_SUMMARY
+done < $SYSTEMVERILOG_FAILED_FILE
+while IFS= read -r LINE; do
+    echo "$LINE" >> $GITHUB_STEP_SUMMARY
+done < $SYSTEMVERILOG_PASSED_FILE
+echo "" >> $GITHUB_STEP_SUMMARY
+
+echo "# Results for tests-read-vcddiff:" >> $GITHUB_STEP_SUMMARY
+echo "| Name | Result |" >> $GITHUB_STEP_SUMMARY
+echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+while IFS= read -r LINE; do
+    echo "$LINE" >> $GITHUB_STEP_SUMMARY
+done < $VCDDIFF_FAILED_FILE
+while IFS= read -r LINE; do
+    echo "$LINE" >> $GITHUB_STEP_SUMMARY
+done < $VCDDIFF_PASSED_FILE
+echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/scripts/generate_summary.sh
+++ b/.github/scripts/generate_summary.sh
@@ -9,34 +9,34 @@ VCDDIFF_FAILED_FILE=$TEST_RESULTS_PREFIX-vcddiff.failed
 
 # Read passed tests if any exist
 if [[ -e $UHDM_PASSED_FILE ]]; then
-    UHDM_PASSED_NUMBER=$(wc -l $UHDM_PASSED_FILE)
+    UHDM_PASSED_NUMBER=$(wc -l < $UHDM_PASSED_FILE)
 else
     UHDM_FAILED_NUMBER=0
 fi
 if [[ -e $SYSTEMVERILOG_PASSED_FILE ]]; then
-    SYSTEMVERILOG_PASSED_NUMBER=$(wc -l $SYSTEMVERILOG_PASSED_FILE)
+    SYSTEMVERILOG_PASSED_NUMBER=$(wc -l < $SYSTEMVERILOG_PASSED_FILE)
 else
     SYSTEMVERILOG_PASSED_NUMBER=0
 fi
 if [[ -e $VCDDIFF_PASSED_FILE ]]; then
-    VCDDIFF_PASSED_NUMBER=$(wc -l $VCDDIFF_PASSED_FILE)
+    VCDDIFF_PASSED_NUMBER=$(wc -l < $VCDDIFF_PASSED_FILE)
 else
     VCDDIFF_PASSED_NUMBER=0
 fi
 
 # Read failed tests if any exist
 if [[ -e $UHDM_FAILED_FILE ]]; then
-    UHDM_FAILED_NUMBER=$(wc -l $UHDM_FAILED_FILE)
+    UHDM_FAILED_NUMBER=$(wc -l < $UHDM_FAILED_FILE)
 else
     UHDM_FAILED_NUMBER=0
 fi
 if [[ -e $SYSTEMVERILOG_FAILED_FILE ]]; then
-    SYSTEMVERILOG_FAILED_NUMBER=$(wc -l $SYSTEMVERILOG_FAILED_FILE)
+    SYSTEMVERILOG_FAILED_NUMBER=$(wc -l < $SYSTEMVERILOG_FAILED_FILE)
 else
     SYSTEMVERILOG_FAILED_NUMBER=0
 fi
 if [[ -e $VCDDIFF_FAILED_FILE ]]; then
-    VCDDIFF_FAILED_NUMBER=$(wc -l $VCDDIFF_FAILED_FILE)
+    VCDDIFF_FAILED_NUMBER=$(wc -l < $VCDDIFF_FAILED_FILE)
 else
     VCDDIFF_FAILED_NUMBER=0
 fi
@@ -51,12 +51,12 @@ else
     echo ":x: SOME TESTS FAILED :x:" > $GITHUB_STEP_SUMMARY
 fi
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "| Name | Tests failed |" >> $GITHUB_STEP_SUMMARY
-echo "|------|--------------|" >> $GITHUB_STEP_SUMMARY
-echo "| tests-read-uhdm          | $UHDM_FAILED_NUMBER |" >> $GITHUB_STEP_SUMMARY
-echo "| tests-read-systemverilog | $SYSTEMVERILOG_FAILED_NUMBER |" >> $GITHUB_STEP_SUMMARY
-echo "| tests-read-vcddiff       | $VCDDIFF_FAILED_NUMBER |" >> $GITHUB_STEP_SUMMARY
-echo "| **Total** | **$TOTAL_FAILED_TESTS** |" >> $GITHUB_STEP_SUMMARY
+echo "| Name | Tests failed | Tests passed |" >> $GITHUB_STEP_SUMMARY
+echo "|------|--------------|--------------|" >> $GITHUB_STEP_SUMMARY
+echo "| tests-read-uhdm          | $UHDM_FAILED_NUMBER | $UHDM_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| tests-read-systemverilog | $SYSTEMVERILOG_FAILED_NUMBER | $SYSTEMVERILOG_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| tests-read-vcddiff       | $VCDDIFF_FAILED_NUMBER | $VCDDIFF_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| **Total** | **$TOTAL_FAILED_TESTS** | **$TOTAL_PASSED_TESTS** |" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "$TOTAL_FAILED_TESTS out of total $TOTAL_TESTS failed." >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/scripts/run_group_test.sh
+++ b/.github/scripts/run_group_test.sh
@@ -1,5 +1,9 @@
 ROOT_DIR=$(dirname $(dirname $(dirname "$0")))
-TEST_CASES="$(cd UHDM-integration-tests && python list.py -d tests -s ibex swerv synthesis opentitan serv serv-minimal hello-uvm assignment-pattern Forever BitsCallOnType OneClass Continue AnonymousUnion FunctionOnDesignLevel ParameterUnpackedArray VoidFunction2Returns PatternStruct ImportedFunctionCallInModuleAndSubmodule VoidFunctionWithoutReturn cmake PutC OneThis CastInFunctionInGenBlock PatternType FunctionOutputArgument GetC ForkJoinTypes EnumFirstInInitial ImportFunction DpiChandle Disable EnumFirst TypedefOnFileLevel UnsizedConstantsParameterParsing Fork PatternInFunction TypedefVariableDimensions ParameterUnpackedLogicArray SelectFromUnpackedInFunction PatternReplication VoidFunction MultiplePrints BitSelectPartSelectInFunction ImportPackageWithFunction ParameterPackedArray StringAssignment SystemFunctions ParameterDoubleUnderscoreInSvFrontend OutputSizeWithParameterOfInstanceInitializedByStructMember ParameterOfSizeOfParametrizedPort ParameterOfSizeOfParametrizedPortInSubmodule ParameterOfSizeOfPort StringAssignConcatenation StringLocalParamInitByConcatenation StringWithBackslash FunctionWithOverriddenParameter RealValue BitsCallOnParametetrizedTypeFromPackage AssignToUnpackedUnionFieldAndReadOtherField IndexedPartSelectInFor NestedPatternPassedAsPort NestedStructArrayParameterInitializedByPatternPassedAsPort PartSelectInFor SelfSelectsInBitSelectAfterBitSelect StructArrayParameterInitializedByPatternPassedAsPort SelectGivenBySelectOnParameterInFunction StreamOperatorBitReverseFunction)"
+if [[ -z $TESTS_TO_SKIP ]]; then
+    TEST_CASES="$(cd UHDM-integration-tests && python list.py -d tests)"
+else
+    TEST_CASES="$(cd UHDM-integration-tests && python list.py -d tests -s $TESTS_TO_SKIP)"
+fi
 TEST_CASES=$(echo $TEST_CASES | sed "s/[][,\"]//g") # Remove characters '[', ']', '"' and ',' from json like array
 
 mkdir -p $ROOT_DIR/test-results

--- a/.github/scripts/run_group_test.sh
+++ b/.github/scripts/run_group_test.sh
@@ -11,15 +11,15 @@ for TEST_CASE in $TEST_CASES;
 do
     export TEST_CASE
     $ROOT_DIR/UHDM-integration-tests/.github/ci.sh
+    TEST_RET=$?
     TEST_CASE=$(echo $TEST_CASE | sed "s/tests\///g")
-    if [ $? -eq 0 ]; then
+    if [ $TEST_RET -eq 0 ]; then
         echo "|$TEST_CASE | :heavy_check_mark: **PASS**|" >> $ROOT_DIR/test-results/test-results.passed
     else
         echo "|$TEST_CASE | :x: **FAIL**|" >> $ROOT_DIR/test-results/test-results.failed
         RET=1
     fi
 done
-
 
 # Leave with non-zero error status if any test failed
 if [[ $RET -ne 0 ]]; then

--- a/.github/scripts/run_group_test.sh
+++ b/.github/scripts/run_group_test.sh
@@ -1,23 +1,23 @@
-echo "|Name | Result|" > $GITHUB_STEP_SUMMARY
-echo "|-----|-------|" >> $GITHUB_STEP_SUMMARY
-
 ROOT_DIR=$(dirname $(dirname $(dirname "$0")))
 TEST_CASES="$(cd UHDM-integration-tests && python list.py -d tests -s ibex swerv synthesis opentitan serv serv-minimal hello-uvm assignment-pattern Forever BitsCallOnType OneClass Continue AnonymousUnion FunctionOnDesignLevel ParameterUnpackedArray VoidFunction2Returns PatternStruct ImportedFunctionCallInModuleAndSubmodule VoidFunctionWithoutReturn cmake PutC OneThis CastInFunctionInGenBlock PatternType FunctionOutputArgument GetC ForkJoinTypes EnumFirstInInitial ImportFunction DpiChandle Disable EnumFirst TypedefOnFileLevel UnsizedConstantsParameterParsing Fork PatternInFunction TypedefVariableDimensions ParameterUnpackedLogicArray SelectFromUnpackedInFunction PatternReplication VoidFunction MultiplePrints BitSelectPartSelectInFunction ImportPackageWithFunction ParameterPackedArray StringAssignment SystemFunctions ParameterDoubleUnderscoreInSvFrontend OutputSizeWithParameterOfInstanceInitializedByStructMember ParameterOfSizeOfParametrizedPort ParameterOfSizeOfParametrizedPortInSubmodule ParameterOfSizeOfPort StringAssignConcatenation StringLocalParamInitByConcatenation StringWithBackslash FunctionWithOverriddenParameter RealValue BitsCallOnParametetrizedTypeFromPackage AssignToUnpackedUnionFieldAndReadOtherField IndexedPartSelectInFor NestedPatternPassedAsPort NestedStructArrayParameterInitializedByPatternPassedAsPort PartSelectInFor SelfSelectsInBitSelectAfterBitSelect StructArrayParameterInitializedByPatternPassedAsPort SelectGivenBySelectOnParameterInFunction StreamOperatorBitReverseFunction)"
 TEST_CASES=$(echo $TEST_CASES | sed "s/[][,\"]//g") # Remove characters '[', ']', '"' and ',' from json like array
 
+mkdir -p $ROOT_DIR/test-results
 for TEST_CASE in $TEST_CASES;
 do
     export TEST_CASE
     $ROOT_DIR/UHDM-integration-tests/.github/ci.sh
+    TEST_CASE=$(echo $TEST_CASE | sed "s/tests\///g")
     if [ $? -eq 0 ]; then
-        echo "|$TEST_CASE | :heavy_check_mark: **PASS**|" >> $GITHUB_STEP_SUMMARY
+        echo "|$TEST_CASE | :heavy_check_mark: **PASS**|" >> $ROOT_DIR/test-results/test-results.passed
     else
-        echo "|$TEST_CASE | :x: **FAIL**|" >> $GITHUB_STEP_SUMMARY
-        export FAILED=1
+        echo "|$TEST_CASE | :x: **FAIL**|" >> $ROOT_DIR/test-results/test-results.failed
+        RET=1
     fi
 done
 
-# Leave with error status if any test failed
-if [[ $FAILED -ne 0 ]]; then
+
+# Leave with non-zero error status if any test failed
+if [[ $RET -ne 0 ]]; then
     exit 1
 fi

--- a/.github/scripts/run_group_test.sh
+++ b/.github/scripts/run_group_test.sh
@@ -1,0 +1,23 @@
+echo "|Name | Result|" > $GITHUB_STEP_SUMMARY
+echo "|-----|-------|" >> $GITHUB_STEP_SUMMARY
+
+ROOT_DIR=$(dirname $(dirname $(dirname "$0")))
+TEST_CASES="$(cd UHDM-integration-tests && python list.py -d tests -s ibex swerv synthesis opentitan serv serv-minimal hello-uvm assignment-pattern Forever BitsCallOnType OneClass Continue AnonymousUnion FunctionOnDesignLevel ParameterUnpackedArray VoidFunction2Returns PatternStruct ImportedFunctionCallInModuleAndSubmodule VoidFunctionWithoutReturn cmake PutC OneThis CastInFunctionInGenBlock PatternType FunctionOutputArgument GetC ForkJoinTypes EnumFirstInInitial ImportFunction DpiChandle Disable EnumFirst TypedefOnFileLevel UnsizedConstantsParameterParsing Fork PatternInFunction TypedefVariableDimensions ParameterUnpackedLogicArray SelectFromUnpackedInFunction PatternReplication VoidFunction MultiplePrints BitSelectPartSelectInFunction ImportPackageWithFunction ParameterPackedArray StringAssignment SystemFunctions ParameterDoubleUnderscoreInSvFrontend OutputSizeWithParameterOfInstanceInitializedByStructMember ParameterOfSizeOfParametrizedPort ParameterOfSizeOfParametrizedPortInSubmodule ParameterOfSizeOfPort StringAssignConcatenation StringLocalParamInitByConcatenation StringWithBackslash FunctionWithOverriddenParameter RealValue BitsCallOnParametetrizedTypeFromPackage AssignToUnpackedUnionFieldAndReadOtherField IndexedPartSelectInFor NestedPatternPassedAsPort NestedStructArrayParameterInitializedByPatternPassedAsPort PartSelectInFor SelfSelectsInBitSelectAfterBitSelect StructArrayParameterInitializedByPatternPassedAsPort SelectGivenBySelectOnParameterInFunction StreamOperatorBitReverseFunction)"
+TEST_CASES=$(echo $TEST_CASES | sed "s/[][,\"]//g") # Remove characters '[', ']', '"' and ',' from json like array
+
+for TEST_CASE in $TEST_CASES;
+do
+    export TEST_CASE
+    $ROOT_DIR/UHDM-integration-tests/.github/ci.sh
+    if [ $? -eq 0 ]; then
+        echo "|$TEST_CASE | :heavy_check_mark: **PASS**|" >> $GITHUB_STEP_SUMMARY
+    else
+        echo "|$TEST_CASE | :x: **FAIL**|" >> $GITHUB_STEP_SUMMARY
+        export FAILED=1
+    fi
+done
+
+# Leave with error status if any test failed
+if [[ $FAILED -ne 0 ]]; then
+    exit 1
+fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,9 +123,16 @@ jobs:
     - name: Build & Test (yosys)
       run: |
         ./.github/scripts/run_group_test.sh
+        mv test-results/test-results.passed test-results/test-results-uhdm.passed || true
+        mv test-results/test-results.failed test-results/test-results-uhdm.failed || true
 
       env:
         TARGET: uhdm/yosys/test-ast
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test-results
+        path: test-results
 
     - name: Upload load graphs
       uses: actions/upload-artifact@v2
@@ -177,9 +184,16 @@ jobs:
     - name: Build & Test (yosys)
       run: |
         ./.github/scripts/run_group_test.sh
+        mv test-results/test-results.passed test-results/test-results-systemverilog.passed || true
+        mv test-results/test-results.failed test-results/test-results-systemverilog.failed || true
 
       env:
         TARGET: uhdm/yosys/test-ast
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test-results
+        path: test-results
 
     - name: Upload load graphs
       uses: actions/upload-artifact@v2
@@ -231,9 +245,16 @@ jobs:
     - name: Generate SV file (Yosys)
       run: |
         ./.github/scripts/run_group_test.sh
+        mv test-results/test-results.passed test-results/test-results-vcddiff.passed || true
+        mv test-results/test-results.failed test-results/test-results-vcddiff.failed || true
 
       env:
         TARGET: uhdm/yosys/test-ast
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: test-results
+        path: test-results
 
     - uses: actions/upload-artifact@v2
       with:
@@ -246,6 +267,24 @@ jobs:
         name: plots
         path: |
           **/plot_*.svg
+
+  generate-tests-summary:
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:jammy
+    if: ${{ always() }}
+    needs: [tests-read-uhdm, tests-read-systemverilog, tests-vcddiff]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Download test results
+      uses: /actions/download-artifact@v3
+      with:
+        name: test-results
+
+    - name: Generate summary
+      run: |
+        ./.github/scripts/generate_summary.sh
 
   tests-formal-verification:
     runs-on: [self-hosted, Linux, X64]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,13 +134,18 @@ jobs:
     - name: Build & Test (yosys)
       run: |
         ./.github/scripts/run_group_test.sh
-        mv test-results/test-results.passed test-results/test-results-uhdm.passed || true
-        mv test-results/test-results.failed test-results/test-results-uhdm.failed || true
 
       env:
         TARGET: uhdm/yosys/test-ast
 
+    - name: Rename test results
+      if: ${{ always() }}
+      run: |
+        mv test-results/test-results.passed test-results/test-results-uhdm.passed || true
+        mv test-results/test-results.failed test-results/test-results-uhdm.failed || true
+
     - uses: actions/upload-artifact@v3
+      if: ${{ always() }}
       with:
         name: test-results
         path: test-results
@@ -195,13 +200,18 @@ jobs:
     - name: Build & Test (yosys)
       run: |
         ./.github/scripts/run_group_test.sh
-        mv test-results/test-results.passed test-results/test-results-systemverilog.passed || true
-        mv test-results/test-results.failed test-results/test-results-systemverilog.failed || true
 
       env:
         TARGET: uhdm/yosys/test-ast
 
+    - name: Rename test results
+      if: ${{ always() }}
+      run: |
+        mv test-results/test-results.passed test-results/test-results-systemverilog.passed || true
+        mv test-results/test-results.failed test-results/test-results-systemverilog.failed || true
+
     - uses: actions/upload-artifact@v3
+      if: ${{ always() }}
       with:
         name: test-results
         path: test-results
@@ -256,18 +266,24 @@ jobs:
     - name: Generate SV file (Yosys)
       run: |
         ./.github/scripts/run_group_test.sh
-        mv test-results/test-results.passed test-results/test-results-vcddiff.passed || true
-        mv test-results/test-results.failed test-results/test-results-vcddiff.failed || true
 
       env:
         TARGET: uhdm/yosys/test-ast
 
+    - name: Rename test results
+      if: ${{ always() }}
+      run: |
+        mv test-results/test-results.passed test-results/test-results-vcddiff.passed || true
+        mv test-results/test-results.failed test-results/test-results-vcddiff.failed || true
+
     - uses: actions/upload-artifact@v3
+      if: ${{ always() }}
       with:
         name: test-results
         path: test-results
 
     - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
       with:
         name: tests-vcddiff-artifacts
         path: UHDM-integration-tests/artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,18 @@ on:
   pull_request:
 
 env:
-  TESTS_PER_GROUP: 300
+  TESTS_TO_SKIP: ibex swerv synthesis opentitan serv serv-minimal hello-uvm assignment-pattern Forever BitsCallOnType OneClass
+    Continue AnonymousUnion FunctionOnDesignLevel ParameterUnpackedArray VoidFunction2Returns PatternStruct
+    ImportedFunctionCallInModuleAndSubmodule VoidFunctionWithoutReturn cmake PutC OneThis CastInFunctionInGenBlock PatternType
+    FunctionOutputArgument GetC ForkJoinTypes EnumFirstInInitial ImportFunction DpiChandle Disable EnumFirst TypedefOnFileLevel
+    UnsizedConstantsParameterParsing Fork PatternInFunction TypedefVariableDimensions ParameterUnpackedLogicArray
+    SelectFromUnpackedInFunction PatternReplication VoidFunction MultiplePrints BitSelectPartSelectInFunction
+    ImportPackageWithFunction ParameterPackedArray StringAssignment SystemFunctions ParameterDoubleUnderscoreInSvFrontend
+    OutputSizeWithParameterOfInstanceInitializedByStructMember ParameterOfSizeOfParametrizedPort ParameterOfSizeOfParametrizedPortInSubmodule
+    ParameterOfSizeOfPort StringAssignConcatenation StringLocalParamInitByConcatenation StringWithBackslash FunctionWithOverriddenParameter
+    RealValue BitsCallOnParametetrizedTypeFromPackage AssignToUnpackedUnionFieldAndReadOtherField IndexedPartSelectInFor
+    NestedPatternPassedAsPort NestedStructArrayParameterInitializedByPatternPassedAsPort PartSelectInFor SelfSelectsInBitSelectAfterBitSelect
+    StructArrayParameterInitializedByPatternPassedAsPort SelectGivenBySelectOnParameterInFunction StreamOperatorBitReverseFunction
 
 jobs:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+env:
+  TESTS_PER_GROUP: 300
+
 jobs:
 
   build-binaries:
@@ -77,64 +80,11 @@ jobs:
         path: |
           **/plot_*.svg
 
-  generate-matrix-yosys:
-    runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy
-    outputs:
-      matrix: ${{ steps.generate-matrix-yosys.outputs.matrix }}
-    steps:
-      - name: Install dependencies
-        run: |
-          apt-get update -qq
-          apt install -y python3
-          update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-
-      - name: Checkout master
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          fetch-depth: 1
-
-      - name: Generate matrix (yosys)
-        id: generate-matrix-yosys
-        run: |
-          matrix="$(cd UHDM-integration-tests && python list.py -d tests -s ibex swerv synthesis opentitan serv serv-minimal hello-uvm assignment-pattern Forever BitsCallOnType OneClass Continue AnonymousUnion FunctionOnDesignLevel ParameterUnpackedArray VoidFunction2Returns PatternStruct ImportedFunctionCallInModuleAndSubmodule VoidFunctionWithoutReturn cmake PutC OneThis CastInFunctionInGenBlock PatternType FunctionOutputArgument GetC ForkJoinTypes EnumFirstInInitial ImportFunction DpiChandle Disable EnumFirst TypedefOnFileLevel UnsizedConstantsParameterParsing Fork PatternInFunction TypedefVariableDimensions ParameterUnpackedLogicArray SelectFromUnpackedInFunction PatternReplication VoidFunction MultiplePrints BitSelectPartSelectInFunction ImportPackageWithFunction ParameterPackedArray StringAssignment SystemFunctions ParameterDoubleUnderscoreInSvFrontend OutputSizeWithParameterOfInstanceInitializedByStructMember ParameterOfSizeOfParametrizedPort ParameterOfSizeOfParametrizedPortInSubmodule ParameterOfSizeOfPort StringAssignConcatenation StringLocalParamInitByConcatenation StringWithBackslash FunctionWithOverriddenParameter RealValue BitsCallOnParametetrizedTypeFromPackage AssignToUnpackedUnionFieldAndReadOtherField IndexedPartSelectInFor NestedPatternPassedAsPort NestedStructArrayParameterInitializedByPatternPassedAsPort PartSelectInFor SelfSelectsInBitSelectAfterBitSelect StructArrayParameterInitializedByPatternPassedAsPort SelectGivenBySelectOnParameterInFunction StreamOperatorBitReverseFunction)"
-          echo "::set-output name=matrix::$matrix"
-          echo "matrix yosys: $matrix"
-
-  generate-matrix-vcddiff:
-    runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy
-    outputs:
-      matrix: ${{ steps.generate-matrix-vcddiff.outputs.matrix }}
-    steps:
-      - name: Install dependencies
-        run: |
-          apt-get update -qq
-          apt install -y python3
-          update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-
-      - name: Checkout master
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          fetch-depth: 1
-
-      - name: Generate matrix (vcddiff)
-        id: generate-matrix-vcddiff
-        run: |
-          matrix="$(cd UHDM-integration-tests && python list.py -d tests -s ibex swerv synthesis opentitan serv serv-minimal hello-uvm assignment-pattern Forever BitsCallOnType OneClass Continue AnonymousUnion FunctionOnDesignLevel ParameterUnpackedArray VoidFunction2Returns PatternStruct ImportedFunctionCallInModuleAndSubmodule VoidFunctionWithoutReturn cmake PutC OneThis CastInFunctionInGenBlock PatternType FunctionOutputArgument GetC ForkJoinTypes EnumFirstInInitial ImportFunction DpiChandle Disable EnumFirst TypedefOnFileLevel UnsizedConstantsParameterParsing Fork PatternInFunction TypedefVariableDimensions ParameterUnpackedLogicArray SelectFromUnpackedInFunction PatternReplication VoidFunction MultiplePrints BitSelectPartSelectInFunction ImportPackageWithFunction ParameterPackedArray StringAssignment SystemFunctions ParameterDoubleUnderscoreInSvFrontend OutputSizeWithParameterOfInstanceInitializedByStructMember ParameterOfSizeOfParametrizedPort ParameterOfSizeOfParametrizedPortInSubmodule ParameterOfSizeOfPort StringAssignConcatenation StringLocalParamInitByConcatenation StringWithBackslash FunctionWithOverriddenParameter RealValue BitsCallOnParametetrizedTypeFromPackage AssignToUnpackedUnionFieldAndReadOtherField IndexedPartSelectInFor NestedPatternPassedAsPort NestedStructArrayParameterInitializedByPatternPassedAsPort PartSelectInFor SelfSelectsInBitSelectAfterBitSelect StructArrayParameterInitializedByPatternPassedAsPort SelectGivenBySelectOnParameterInFunction StreamOperatorBitReverseFunction)"
-          matrix=$(echo $matrix | sed "s/tests\///g")
-          echo "::set-output name=matrix::$matrix"
-          echo "matrix vcddiff: $matrix"
-
   tests-read-uhdm:
     runs-on: [self-hosted, Linux, X64]
     container: ubuntu:jammy
-    needs: [build-binaries, generate-matrix-yosys]
+    needs: [build-binaries]
     strategy:
-      matrix:
-        TEST_CASE_YOSYS: ${{ fromJson(needs.generate-matrix-yosys.outputs.matrix) }}
       fail-fast:
         false
     env:
@@ -154,6 +104,7 @@ jobs:
         add-apt-repository ppa:ubuntu-toolchain-r/test
         apt-get update -qq
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
     - uses: actions/checkout@v2
       with:
@@ -170,9 +121,10 @@ jobs:
       run: tar -xf binaries.tar
 
     - name: Build & Test (yosys)
-      run: ./UHDM-integration-tests/.github/ci.sh
+      run: |
+        ./.github/scripts/run_group_test.sh
+
       env:
-        TEST_CASE: ${{ matrix.TEST_CASE_YOSYS }}
         TARGET: uhdm/yosys/test-ast
 
     - name: Upload load graphs
@@ -185,10 +137,8 @@ jobs:
   tests-read-systemverilog:
     runs-on: [self-hosted, Linux, X64]
     container: ubuntu:jammy
-    needs: [build-binaries, generate-matrix-yosys]
+    needs: [build-binaries]
     strategy:
-      matrix:
-        TEST_CASE_YOSYS: ${{ fromJson(needs.generate-matrix-yosys.outputs.matrix) }}
       fail-fast:
         false
     env:
@@ -208,6 +158,7 @@ jobs:
         add-apt-repository ppa:ubuntu-toolchain-r/test
         apt-get update -qq
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
     - uses: actions/checkout@v2
       with:
@@ -224,9 +175,10 @@ jobs:
       run: tar -xf binaries.tar
 
     - name: Build & Test (yosys)
-      run: ./UHDM-integration-tests/.github/ci.sh
+      run: |
+        ./.github/scripts/run_group_test.sh
+
       env:
-        TEST_CASE: ${{ matrix.TEST_CASE_YOSYS }}
         TARGET: uhdm/yosys/test-ast
 
     - name: Upload load graphs
@@ -239,10 +191,8 @@ jobs:
   tests-vcddiff:
     runs-on: [self-hosted, Linux, X64]
     container: ubuntu:jammy
-    needs: [build-binaries, generate-matrix-vcddiff]
+    needs: [build-binaries]
     strategy:
-      matrix:
-        TEST_CASE_VCDDIFF: ${{ fromJson(needs.generate-matrix-vcddiff.outputs.matrix) }}
       fail-fast:
         false
     env:
@@ -262,6 +212,7 @@ jobs:
         add-apt-repository ppa:ubuntu-toolchain-r/test
         apt-get update -qq
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
     - uses: actions/checkout@v2
       with:
@@ -279,16 +230,15 @@ jobs:
 
     - name: Generate SV file (Yosys)
       run: |
-        ./UHDM-integration-tests/.github/ci.sh
+        ./.github/scripts/run_group_test.sh
 
       env:
-        TEST_CASE: tests/${{ matrix.TEST_CASE_VCDDIFF }}
         TARGET: uhdm/yosys/test-ast
 
     - uses: actions/upload-artifact@v2
       with:
-        name: ${{ matrix.TEST_CASE_VCDDIFF }}.sv
-        path: UHDM-integration-tests/build/yosys.sv
+        name: tests-vcddiff-artifacts
+        path: UHDM-integration-tests/artifacts
 
     - name: Upload load graphs
       uses: actions/upload-artifact@v2
@@ -323,7 +273,7 @@ jobs:
         apt install -y software-properties-common
         add-apt-repository ppa:ubuntu-toolchain-r/test
         apt-get update -qq
-        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev time
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev time python3
 
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
There is almost 800 jobs generated on each CI run at this moment, this PR introduces grouping of short tests which significantly lowers number of generated jobs. This change makes going through CI results easier for user and loading them should be more lightweight for GH servers.