### PR TITLE
Change machine for opentitan_synth job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -480,7 +480,7 @@ jobs:
       CXX: g++-9
       DEBIAN_FRONTEND: noninteractive
       GHA_EXTERNAL_DISK: "tools"
-      GHA_MACHINE_TYPE: "n2-highmem-4"
+      GHA_MACHINE_TYPE: "n2-highmem-8"
 
     steps:
 

--- a/formal/passlist.txt
+++ b/formal/passlist.txt
@@ -266,3 +266,4 @@ simple_signedexpr.v
 simple_scopes.v
 simple_loop_var_shadow.v
 simple_const_func_shadow.v
+core_net_or_var.sv


### PR DESCRIPTION
We need more memory to run opentitan_synth, so we are changing the machine with 32G RAM to the one with 64G RAM.