### PR TITLE
Change CI runner for formal verification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -353,7 +353,7 @@ jobs:
       GIT_HTTP_LOW_SPEED_LIMIT: 1
       GIT_HTTP_LOW_SPEED_TIME: 600
       DEBIAN_FRONTEND: noninteractive
-      GHA_MACHINE_TYPE: "n2-standard-4"
+      GHA_MACHINE_TYPE: "n2-highmem-4"
       PARSER: yosys-plugin
       TEST_SUITE: ${{ matrix.test-suite }}
 


### PR DESCRIPTION
Formal verification CI occasionally runs into OOM errors:

- https://github.com/antmicro/yosys-systemverilog/actions/runs/3692531494
- https://github.com/antmicro/yosys-systemverilog/actions/runs/3695295880

This PR changes the runner type to offer more memory.