### PR TITLE
Improve flow for OpenTitan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -608,6 +608,9 @@ jobs:
     - name: Generate summary
       run: cat ./UHDM-integration-tests/opentitan_report.txt | tee $GITHUB_STEP_SUMMARY
 
+    - name: Prune the build directory
+      run: find ./UHDM-integration-tests/opentitan_build -name "src" | xargs rm -rf
+
     - name: Upload dependency graph
       if: ${{ always() }}
       uses: actions/upload-artifact@v2

--- a/uhdm-tests/opentitan/iterate_cores.py
+++ b/uhdm-tests/opentitan/iterate_cores.py
@@ -123,12 +123,14 @@ with open('result.txt', 'w') as f:
         f.write('|----|\n')
         for node in new_passes:
             f.write(f'|{node}|\n')
+        f.write('\n')
 
     if new_fails:
         f.write('| Unexpected fail for cores: |\n')
         f.write('|----|\n')
         for node in new_fails:
             f.write(f'|{node}|\n')
+        f.write('\n')
 
 
 # set node colors and status attributes


### PR DESCRIPTION
This fixes formatting, where two tables could be joined into one because a newline character was missing.

Also, the CI runs were very long due to the sizes of artifacts (`2min 23s` of processing OpenTitan, and then over `17 min` of uploading logs)
So, I'm removing all source files from the artifacts. This reduces the size of unpacked logs from 130M to 40M.

The whole job of `opentitan_parse_report` took 11min 58s with this change.