### PR TITLE
CI: Use Ubuntu mirrors & Revert to ubuntu:jammy container image.

### DIFF
--- a/.github/scripts/set-up-common-ubuntu-configuration.sh
+++ b/.github/scripts/set-up-common-ubuntu-configuration.sh
@@ -20,6 +20,10 @@ declare -ra mirrors=(
 	## Official regional mirror
 	http://us.archive.ubuntu.com/ubuntu/
 
+	# The 4 non-ubuntu URLs below were picked because they have highest
+	# throughput from all official US mirrors (20+ Gbps) according
+	# to https://launchpad.net/ubuntu/+archivemirrors.
+
 	## US, 100 Gbps; https://launchpad.net/ubuntu/+mirror/enzu.com
 	http://mirror.enzu.com/ubuntu/
 	## US, 20 Gbps; https://launchpad.net/ubuntu/+mirror/mirror.genesisadaptive.com-archive
@@ -52,6 +56,8 @@ begin_group 'Add extra APT configuration'
 
 apt_ci_config=/etc/apt/apt.conf.d/99-ci
 
+# Set retry count to 6, and disables ipv6 (ubuntu servers have problems with
+# it, and it is used by default).
 printf '%s\n' \
 		'Acquire::ForceIPv4 "true";' \
 		'Acquire::Retries "6";' \

--- a/.github/scripts/set-up-common-ubuntu-configuration.sh
+++ b/.github/scripts/set-up-common-ubuntu-configuration.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#-----------------------------------------------------------------------------
+# Initial setup of a container image. This is called at the beginning of
+# every job that uses Ubuntu container image.
+#-----------------------------------------------------------------------------
+set -e -u -o pipefail
+shopt -s nullglob
+shopt -s extglob
+
+begin_group() { printf '::group::%s\n' "$*"; }
+end_group() { printf '::endgroup::\n'; }
+
+#-----------------------------------------------------------------------------
+begin_group 'Use regional (US) Ubuntu repository mirrors'
+#-----------------------------------------------------------------------------
+
+sources_list=/etc/apt/sources.list
+
+declare -ra mirrors=(
+	## Official regional mirror
+	http://us.archive.ubuntu.com/ubuntu/
+
+	## US, 100 Gbps; https://launchpad.net/ubuntu/+mirror/enzu.com
+	http://mirror.enzu.com/ubuntu/
+	## US, 20 Gbps; https://launchpad.net/ubuntu/+mirror/mirror.genesisadaptive.com-archive
+	http://mirror.genesisadaptive.com/ubuntu/
+	## US, 20 Gbps; https://launchpad.net/ubuntu/+mirror/mirror.math.princeton.edu-archive
+	http://mirror.math.princeton.edu/pub/ubuntu/
+	## US, 20 Gbps; https://launchpad.net/ubuntu/+mirror/mirror.pit.teraswitch.com-archive
+	http://mirror.pit.teraswitch.com/ubuntu/
+
+	## Main official repository
+	http://archive.ubuntu.com/ubuntu/
+)
+{
+	printf 'deb %s jammy main restricted universe multiverse\n' "${mirrors[@]}"
+	printf '\n'
+	printf 'deb %s jammy-updates main restricted universe multiverse\n' "${mirrors[@]}"
+	printf '\n'
+	printf 'deb %s jammy-backports main restricted universe multiverse\n' "${mirrors[@]}"
+	printf '\n'
+
+	# Official security updates repo
+	printf 'deb http://security.ubuntu.com/ubuntu/ jammy-security main restricted universe multiverse\n'
+} | tee "$sources_list"
+
+end_group
+
+#-----------------------------------------------------------------------------
+begin_group 'Add extra APT configuration'
+#-----------------------------------------------------------------------------
+
+apt_ci_config=/etc/apt/apt.conf.d/99-ci
+
+printf '%s\n' \
+		'Acquire::ForceIPv4 "true";' \
+		'Acquire::Retries "6";' \
+		| tee "$apt_ci_config"
+
+end_group
+
+#-----------------------------------------------------------------------------

--- a/.github/scripts/set-up-common-ubuntu-configuration.sh
+++ b/.github/scripts/set-up-common-ubuntu-configuration.sh
@@ -7,8 +7,23 @@ set -e -u -o pipefail
 shopt -s nullglob
 shopt -s extglob
 
+# Included only in CI, so `$0` should be relative to repository directory.
+declare -r THIS_FILE="$0"
+
+emit_error() { printf '::error file=%s::%s\n' "$THIS_FILE" "$*"; }
 begin_group() { printf '::group::%s\n' "$*"; }
 end_group() { printf '::endgroup::\n'; }
+
+# Check whether the OS is compatible Ubuntu version.
+(
+	# https://www.freedesktop.org/software/systemd/man/os-release.html
+	source /etc/os-release
+	if ! [[ "${ID:-}" == 'ubuntu'
+			&& ( "${VERSION_ID:-}" == '22.04' || "${VERSION_CODENAME:-}" == 'jammy' ) ]]; then
+		emit_error "Incompatible OS (expected Ubuntu 22.04 AKA jammy), please update `${THIS_FILE}`."
+		exit 1
+	fi
+)
 
 #-----------------------------------------------------------------------------
 begin_group 'Use regional (US) Ubuntu repository mirrors'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
   build-binaries:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     env:
       CC: gcc-9
       CXX: g++-9
@@ -117,7 +117,7 @@ jobs:
 
   tests-read-uhdm:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     needs: [build-binaries]
     strategy:
       fail-fast:
@@ -187,7 +187,7 @@ jobs:
 
   tests-read-systemverilog:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     needs: [build-binaries]
     strategy:
       fail-fast:
@@ -257,7 +257,7 @@ jobs:
 
   tests-vcddiff:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     needs: [build-binaries]
     strategy:
       fail-fast:
@@ -333,7 +333,7 @@ jobs:
 
   generate-tests-summary:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     if: ${{ always() }}
     needs: [tests-read-uhdm, tests-read-systemverilog, tests-vcddiff]
     steps:
@@ -355,7 +355,7 @@ jobs:
 
   tests-formal-verification:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     needs: [build-binaries]
     strategy:
       matrix:
@@ -431,7 +431,7 @@ jobs:
 
   ibex_synth:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     needs: build-binaries
     env:
       CC: gcc-9
@@ -493,7 +493,7 @@ jobs:
   opentitan_9d82960888_synth:
     runs-on: [self-hosted, Linux, X64]
     # vivado is linked with libraries used in this version of ubuntu
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     needs: build-binaries
     env:
       CC: gcc-9
@@ -584,7 +584,7 @@ jobs:
   opentitan_parse_report:
     runs-on: [self-hosted, Linux, X64]
     # vivado is linked with libraries used in this version of ubuntu
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     needs: build-binaries
     env:
       CC: gcc-9
@@ -666,7 +666,7 @@ jobs:
 
   swerv_synth:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     needs: build-binaries
     env:
       CC: gcc-9
@@ -818,7 +818,7 @@ jobs:
 
   ibex_synth_symbiflow:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     needs: build-binaries
     env:
       CC: gcc-9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,13 @@ jobs:
       PLUGIN_ASAN: 1
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
 
     - name: Install dependencies
       run: |
@@ -60,11 +67,6 @@ jobs:
         pip install orderedmultidict
         pip install --upgrade pip
         pip install cmake
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Create Cache Timestamp
       id: cache_timestamp
@@ -130,6 +132,14 @@ jobs:
       PARSER: surelog
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+
     - name: Install dependencies
       run: |
         apt-get update -qq
@@ -138,11 +148,6 @@ jobs:
         apt-get update -qq
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -197,6 +202,14 @@ jobs:
       PARSER: yosys-plugin
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+
     - name: Install dependencies
       run: |
         apt-get update -qq
@@ -205,11 +218,6 @@ jobs:
         apt-get update -qq
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -264,6 +272,14 @@ jobs:
       PARSER: surelog
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+
     - name: Install dependencies
       run: |
         apt-get update -qq
@@ -272,11 +288,6 @@ jobs:
         apt-get update -qq
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -326,8 +337,12 @@ jobs:
     if: ${{ always() }}
     needs: [tests-read-uhdm, tests-read-systemverilog, tests-vcddiff]
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
 
     - name: Download test results
       uses: /actions/download-artifact@v3
@@ -358,6 +373,14 @@ jobs:
       TEST_SUITE: ${{ matrix.test-suite }}
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+
     - name: Install dependencies
       run: |
         apt-get update -qq
@@ -365,11 +388,6 @@ jobs:
         add-apt-repository ppa:ubuntu-toolchain-r/test
         apt-get update -qq
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev time python3
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -422,6 +440,13 @@ jobs:
       GHA_EXTERNAL_DISK: "tools"
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
 
     - name: Install dependencies
       run: |
@@ -432,11 +457,6 @@ jobs:
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip libtinfo5
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -483,6 +503,13 @@ jobs:
       GHA_MACHINE_TYPE: "n2-highmem-8"
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
 
     - name: Install dependencies
       run: |
@@ -493,11 +520,6 @@ jobs:
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip libtinfo5
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -544,7 +566,7 @@ jobs:
           #      if: ${{ github.event_name == 'pull_request' }}
           #      run: |
           #        mkdir compare
-          #        ./github/scripts/compare_ast.py opentitan-yosys.ast yosys.ast
+          #        ./.github/scripts/compare_ast.py opentitan-yosys.ast yosys.ast
 
     - uses: actions/upload-artifact@v2
       with:
@@ -571,6 +593,14 @@ jobs:
       GHA_EXTERNAL_DISK: "tools"
       GHA_MACHINE_TYPE: "n2-highmem-8"
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+
     - name: Install dependencies
       run: |
         apt-get update -qq
@@ -580,11 +610,6 @@ jobs:
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip libtinfo5 graphviz libgraphviz-dev pkg-config
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -649,6 +674,13 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
 
     - name: Install dependencies
       run: |
@@ -659,11 +691,6 @@ jobs:
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
-
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Download binaries
       uses: actions/download-artifact@v2
@@ -799,6 +826,13 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
 
     steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
 
     - name: Install dependencies
       run: |
@@ -809,10 +843,6 @@ jobs:
         apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip wget
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        fetch-depth: 1
 
     - name: Download binaries
       uses: actions/download-artifact@v2

--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -15,11 +15,14 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
 
     steps:
-
     - name: Prepare Repository
       uses: actions/checkout@v2
       with:
         submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
 
     - name: Install Prerequisites
       run: |
@@ -50,11 +53,14 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
 
     steps:
-
     - name: Prepare Repository
       uses: actions/checkout@v2
       with:
         submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up common Ubuntu configuration
+      run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
 
     - name: Install Prerequisites
       run: |

--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -10,7 +10,7 @@ jobs:
 
   test-plugin-from-sources:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     env:
       DEBIAN_FRONTEND: noninteractive
 
@@ -48,7 +48,7 @@ jobs:
 
   test-plugin-ubuntu:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:jammy-20221130
+    container: ubuntu:jammy
     env:
       DEBIAN_FRONTEND: noninteractive
 


### PR DESCRIPTION
This adds a few US mirrors to the repository list, sets retry count to 6, and disables ipv6 (ubuntu servers have problems with it, and it is used by default).
The 4 non-ubuntu URLs were picked because they have highest throughput from all official US mirrors (20+ Gbps) according to https://launchpad.net/ubuntu/+archivemirrors.

Generally this works so that when the first mirror from the list fails, apt tries a next one.