### PR TITLE
CI: use pipx instead of pip

### DIFF
--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -100,8 +100,9 @@ jobs:
       - name: Install Prerequisites
         run: |
           apt-get update -qq
-          apt-get install -y python3-pip git
-          pip3 install git+https://github.com/antmicro/tuttest#egg=tuttest
+          apt-get install -y pipx git
+          echo "${HOME}/.local/bin:" >> $GITHUB_PATH
+          pipx install git+https://github.com/antmicro/tuttest#egg=tuttest
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
This PR aims to fix failing tuttest on debian-sid (https://github.com/antmicro/yosys-systemverilog/actions/runs/4162797343/jobs/7202408929#step:4:1069):

```
11:10:39 | error: externally-managed-environment
11:10:39 | 
11:10:39 | × This environment is externally managed
11:10:39 | ╰─> To install Python packages system-wide, try apt install
11:10:39 |     python3-xyz, where xyz is the package you are trying to
11:10:39 |     install.
11:10:39 |     
11:10:39 |     If you wish to install a non-Debian-packaged Python package,
11:10:39 |     create a virtual environment using python3 -m venv path/to/venv.
11:10:39 |     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
11:10:39 |     sure you have python3-full installed.
11:10:39 |     
11:10:39 |     If you wish to install a non-Debian packaged Python application,
11:10:39 |     it may be easiest to use pipx install xyz, which will manage a
11:10:39 |     virtual environment for you. Make sure you have pipx installed.
11:10:39 |     
11:10:39 |     See /usr/share/doc/python3.11/README.venv for more information.
```
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>