### PR TITLE
CI: set PIPX_BIN_DIR instead of PATH

### DIFF
--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -90,6 +90,7 @@ jobs:
     container: debian:sid
     env:
       DEBIAN_FRONTEND: noninteractive
+      PIPX_BIN_DIR: /usr/local/bin
 
     steps:
       - name: Prepare Repository
@@ -101,7 +102,6 @@ jobs:
         run: |
           apt-get update -qq
           apt-get install -y pipx git
-          echo "${HOME}/.local/bin:" >> $GITHUB_PATH
           pipx install git+https://github.com/antmicro/tuttest#egg=tuttest
 
       - name: Install Dependencies


### PR DESCRIPTION
Ref: https://github.com/antmicro/yosys-systemverilog/pull/1499#discussion_r1104506889

Setting ``GITHUB_PATH`` in custom-runners requires additional ``:`` at the end and it is confusing.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>