### PR TITLE
Change Yosys options used by Ibex & use upstream Yosys

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "yosys"]
 	path = yosys
-	url = https://github.com/antmicro/yosys.git
+	url = https://github.com/YosysHQ/yosys.git
 [submodule "Surelog"]
 	path = Surelog
 	url = https://github.com/chipsalliance/Surelog.git

--- a/uhdm-tests/ibex/top_artya7_core.patch
+++ b/uhdm-tests/ibex/top_artya7_core.patch
@@ -94,13 +94,13 @@ index 4493a8ae..bbe9c6c8 100644
        vivado:
          part: "xc7a100tcsg324-1"  # Default to Arty A7-100
 +        synth: "yosys"
-+        yosys_synth_options: ['-iopad', '-family xc7', '-run :check', "frontend=surelog"]
 +        yosys_read_options: ['-debug']
++        yosys_synth_options: ['-iopad', '-family xc7', "frontend=surelog"]
 +        surelog_options: ['--disable-feature=parametersubstitution', '-DSYNTHESIS']
 +      yosys:
 +        arch: "xilinx"
-+        yosys_synth_options: ['-iopad', '-family xc7', '-run :check', "frontend=surelog"]
 +        yosys_read_options: ['-debug']
++        yosys_synth_options: ['-iopad', '-family xc7', "frontend=surelog"]
 +        surelog_options: ['--disable-feature=parametersubstitution', '-DSYNTHESIS']
 +      symbiflow:
 +        package: "csg324-1"


### PR DESCRIPTION
While implementing a block ram demo similar to one from Ibex, but using `read_verilog` instead of `read_systemverilog`, I had a problem with reproducing the issue my fix was intended to fix. In the demo Yosys was able to automatically truncate wires from 64 to 32 bit where necessary, which hasn't happened when building Ibex.
Turns out `synth_verilog` has been executed partially due to `-run :check` option. Without this option everything builds successfully with upstream Yosys.