### PR TITLE
CI: Fold and merge tables in parsing tests results summary.

### DIFF
--- a/.github/scripts/generate_summary.sh
+++ b/.github/scripts/generate_summary.sh
@@ -1,3 +1,8 @@
+#!/bin/bash
+set -e -u -o pipefail
+shopt -s nullglob
+shopt -s extglob
+
 ROOT_DIR=$(dirname $(dirname $(dirname "$0")))
 TEST_RESULTS_PREFIX=$ROOT_DIR/test-results
 UHDM_PASSED_FILE=$TEST_RESULTS_PREFIX-uhdm.passed
@@ -39,34 +44,80 @@ else
     echo ":x: SOME TESTS FAILED :x:" > $GITHUB_STEP_SUMMARY
 fi
 echo "" >> $GITHUB_STEP_SUMMARY
-echo "| Name | Tests failed | Tests passed |" >> $GITHUB_STEP_SUMMARY
-echo "|------|--------------|--------------|" >> $GITHUB_STEP_SUMMARY
-echo "| tests-read-uhdm          | $UHDM_FAILED_NUMBER | $UHDM_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
-echo "| tests-read-systemverilog | $SYSTEMVERILOG_FAILED_NUMBER | $SYSTEMVERILOG_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
-echo "| **Total** | **$TOTAL_FAILED_TESTS** | **$TOTAL_PASSED_TESTS** |" >> $GITHUB_STEP_SUMMARY
+echo "| Tool/Parser          | Failed | Passed |" >> $GITHUB_STEP_SUMMARY
+echo "|:---------------------|-------:|-------:|" >> $GITHUB_STEP_SUMMARY
+echo "| Surelog              | $UHDM_FAILED_NUMBER | $UHDM_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| SystemVerilog Plugin | $SYSTEMVERILOG_FAILED_NUMBER | $SYSTEMVERILOG_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| **Total**            | **$TOTAL_FAILED_TESTS** | **$TOTAL_PASSED_TESTS** |" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "$TOTAL_FAILED_TESTS out of total $TOTAL_TESTS failed." >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 
-echo "# Results for tests-read-uhdm:" >> $GITHUB_STEP_SUMMARY
-echo "| Name | Result |" >> $GITHUB_STEP_SUMMARY
-echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-while IFS= read -r LINE; do
-    echo "$LINE" >> $GITHUB_STEP_SUMMARY
-done < $UHDM_FAILED_FILE
-while IFS= read -r LINE; do
-    echo "$LINE" >> $GITHUB_STEP_SUMMARY
-done < $UHDM_PASSED_FILE
-echo "" >> $GITHUB_STEP_SUMMARY
+declare -A surelog_results=()
+declare -A sv_plugin_results=()
+for result_file in "$SYSTEMVERILOG_FAILED_FILE" "$SYSTEMVERILOG_PASSED_FILE"; do
+    if [[ -f "$result_file" ]]; then
+        while read -r test_name test_result; do
+            sv_plugin_results[$test_name]=${test_result}
+        done < "$result_file"
+    fi
+done
+for result_file in "$UHDM_FAILED_FILE" "$UHDM_PASSED_FILE"; do
+    if [[ -f "$result_file" ]]; then
+        while read -r test_name test_result; do
+            surelog_results[$test_name]=${test_result}
+        done < "$result_file"
+    fi
+done
 
-echo "# Results for tests-read-systemverilog:" >> $GITHUB_STEP_SUMMARY
-echo "| Name | Result |" >> $GITHUB_STEP_SUMMARY
-echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-while IFS= read -r LINE; do
-    echo "$LINE" >> $GITHUB_STEP_SUMMARY
-done < $SYSTEMVERILOG_FAILED_FILE
-while IFS= read -r LINE; do
-    echo "$LINE" >> $GITHUB_STEP_SUMMARY
-done < $SYSTEMVERILOG_PASSED_FILE
-echo "" >> $GITHUB_STEP_SUMMARY
+declare -a results_00=()
+declare -a results_10=()
+declare -a results_01=()
+declare -a results_11=()
+
+declare -r pass_str=':heavy_check_mark: **PASS**'
+declare -r fail_str=':x: **FAIL**'
+
+for test_name in "${!surelog_results[@]}"; do
+    case "${surelog_results[$test_name]:-0}${sv_plugin_results[$test_name]:-0}" in
+        [^1][^1])
+            results_00+=("| $fail_str | $fail_str | $test_name |")
+        ;;
+        1[^1])
+            results_10+=("| $pass_str | $fail_str | $test_name |")
+        ;;
+        [^1]1)
+            results_01+=("| $fail_str | $pass_str | $test_name |")
+        ;;
+        11)
+            results_11+=("| $pass_str | $pass_str | $test_name |")
+        ;;
+    esac
+done
+
+print_ln() { printf '%s\n' "$@"; }
+
+{
+    if (( ${#results_00[@]} + ${#results_10[@]} + ${#results_01[@]} > 0 )); then
+        print_ln '<details open>'
+        print_ln '<summary><strong>List of failed tests</strong></summary>'
+        print_ln ''
+        print_ln '| Surelog | SV Plugin | Test |'
+        print_ln '|:-------:|:---------:|:-----|'
+        print_ln "${results_00[@]}" | sort
+        print_ln "${results_10[@]}" | sort
+        print_ln "${results_01[@]}" | sort
+        print_ln ''
+        print_ln '</details>'
+    fi
+
+    print_ln '<details>'
+    print_ln '<summary><strong>List of passed tests</strong></summary>'
+    print_ln ''
+    print_ln '| Surelog | SV Plugin | Test |'
+    print_ln '|:-------:|:---------:|:-----|'
+    print_ln "${results_11[@]}" | sort
+    print_ln ''
+    print_ln '</details>'
+} >> $GITHUB_STEP_SUMMARY

--- a/.github/scripts/generate_summary.sh
+++ b/.github/scripts/generate_summary.sh
@@ -71,6 +71,9 @@ for result_file in "$UHDM_FAILED_FILE" "$UHDM_PASSED_FILE"; do
     fi
 done
 
+# List of tests with specific combination of results.
+# 0 means "fail", 1 means "pass". Each digit represents one column in the table
+# (`read_uhdm` and `read_systemverilog`, respectivelly).
 declare -a results_00=()
 declare -a results_10=()
 declare -a results_01=()
@@ -79,6 +82,7 @@ declare -a results_11=()
 declare -r pass_str=':heavy_check_mark: **PASS**'
 declare -r fail_str=':x: **FAIL**'
 
+# `[^1]` below is used instead of `0` to catch any unexpected values as failures.
 for test_name in "${!uhdm_results[@]}"; do
     case "${uhdm_results[$test_name]:-0}${systemverilog_results[$test_name]:-0}" in
         [^1][^1])

--- a/.github/scripts/generate_summary.sh
+++ b/.github/scripts/generate_summary.sh
@@ -46,27 +46,27 @@ fi
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "| Tool/Parser          | Failed | Passed |" >> $GITHUB_STEP_SUMMARY
 echo "|:---------------------|-------:|-------:|" >> $GITHUB_STEP_SUMMARY
-echo "| Surelog              | $UHDM_FAILED_NUMBER | $UHDM_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
-echo "| SystemVerilog Plugin | $SYSTEMVERILOG_FAILED_NUMBER | $SYSTEMVERILOG_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| `read-uhdm`          | $UHDM_FAILED_NUMBER | $UHDM_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
+echo "| `read-systemverilog` | $SYSTEMVERILOG_FAILED_NUMBER | $SYSTEMVERILOG_PASSED_NUMBER |" >> $GITHUB_STEP_SUMMARY
 echo "| **Total**            | **$TOTAL_FAILED_TESTS** | **$TOTAL_PASSED_TESTS** |" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "$TOTAL_FAILED_TESTS out of total $TOTAL_TESTS failed." >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 echo "" >> $GITHUB_STEP_SUMMARY
 
-declare -A surelog_results=()
-declare -A sv_plugin_results=()
+declare -A uhdm_results=()
+declare -A systemverilog_results=()
 for result_file in "$SYSTEMVERILOG_FAILED_FILE" "$SYSTEMVERILOG_PASSED_FILE"; do
     if [[ -f "$result_file" ]]; then
         while read -r test_name test_result; do
-            sv_plugin_results[$test_name]=${test_result}
+            systemverilog_results[$test_name]=${test_result}
         done < "$result_file"
     fi
 done
 for result_file in "$UHDM_FAILED_FILE" "$UHDM_PASSED_FILE"; do
     if [[ -f "$result_file" ]]; then
         while read -r test_name test_result; do
-            surelog_results[$test_name]=${test_result}
+            uhdm_results[$test_name]=${test_result}
         done < "$result_file"
     fi
 done
@@ -79,8 +79,8 @@ declare -a results_11=()
 declare -r pass_str=':heavy_check_mark: **PASS**'
 declare -r fail_str=':x: **FAIL**'
 
-for test_name in "${!surelog_results[@]}"; do
-    case "${surelog_results[$test_name]:-0}${sv_plugin_results[$test_name]:-0}" in
+for test_name in "${!uhdm_results[@]}"; do
+    case "${uhdm_results[$test_name]:-0}${systemverilog_results[$test_name]:-0}" in
         [^1][^1])
             results_00+=("| $fail_str | $fail_str | $test_name |")
         ;;
@@ -103,8 +103,8 @@ print_ln() { printf '%s\n' "$@"; }
         print_ln '<details open>'
         print_ln '<summary><strong>List of failed tests</strong></summary>'
         print_ln ''
-        print_ln '| Surelog | SV Plugin | Test |'
-        print_ln '|:-------:|:---------:|:-----|'
+        print_ln '| `read_uhdm` | `read_systemverilog` | Test |'
+        print_ln '|:-----------:|:--------------------:|:-----|'
         print_ln "${results_00[@]}" | sort
         print_ln "${results_10[@]}" | sort
         print_ln "${results_01[@]}" | sort
@@ -115,8 +115,8 @@ print_ln() { printf '%s\n' "$@"; }
     print_ln '<details>'
     print_ln '<summary><strong>List of passed tests</strong></summary>'
     print_ln ''
-    print_ln '| Surelog | SV Plugin | Test |'
-    print_ln '|:-------:|:---------:|:-----|'
+    print_ln '| `read_uhdm` | `read_systemverilog` | Test |'
+    print_ln '|:-----------:|:--------------------:|:-----|'
     print_ln "${results_11[@]}" | sort
     print_ln ''
     print_ln '</details>'

--- a/.github/scripts/run_group_test.sh
+++ b/.github/scripts/run_group_test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ROOT_DIR=$(dirname $(dirname $(dirname "$0")))
 if [[ -z $TESTS_TO_SKIP ]]; then
     TEST_CASES="$(cd UHDM-integration-tests && python list.py -d tests)"
@@ -12,11 +13,11 @@ do
     export TEST_CASE
     $ROOT_DIR/UHDM-integration-tests/.github/ci.sh
     TEST_RET=$?
-    TEST_CASE=$(echo $TEST_CASE | sed "s/tests\///g")
-    if [ $TEST_RET -eq 0 ]; then
-        echo "|$TEST_CASE | :heavy_check_mark: **PASS**|" >> $ROOT_DIR/test-results/test-results.passed
+    TEST_CASE="${TEST_CASE//tests\//}"
+    if [[ $TEST_RET -eq 0 ]]; then
+        printf '%s\t%s\n' "$TEST_CASE" '1' >> $ROOT_DIR/test-results/test-results.passed
     else
-        echo "|$TEST_CASE | :x: **FAIL**|" >> $ROOT_DIR/test-results/test-results.failed
+        printf '%s\t%s\n' "$TEST_CASE" '0' >> $ROOT_DIR/test-results/test-results.failed
         RET=1
     fi
 done


### PR DESCRIPTION
When everything passed, the list of tests is initially folded.

[Live demo](https://github.com/antmicro/yosys-systemverilog/actions/runs/4258279850)

![Screen Shot 2023-02-27 at 13 04 22](https://user-images.githubusercontent.com/4888536/221559889-7a90e15c-3a5d-4967-a195-38d0b1b3935e.png)

---

When there are failures, their list is initially visible. The separate list of passed tests is initially folded. Note: failures on the screenshot are made up and were artificially injected into test outputs just to show and test how it would look.

[Live demo](https://github.com/antmicro/yosys-systemverilog/actions/runs/4258278521)

![Screen Shot 2023-02-27 at 13 04 36](https://user-images.githubusercontent.com/4888536/221560909-b4453291-a6b9-428c-b684-35a375f21111.png)

---

Up until now there were two tables. Both with the same tests, but with results for different tool.
Now there's just one table, with results for both tools in separate columns.

![Screen Shot 2023-02-27 at 13 05 29](https://user-images.githubusercontent.com/4888536/221562159-433040a8-cbec-4023-9d8c-a3f0e306da60.png)