### PR TITLE
synth_xilinx -> synth in formal verification

### DIFF
--- a/formal_verification.py
+++ b/formal_verification.py
@@ -150,7 +150,7 @@ def run_surelog(test_path, output_dir, prefix=""):
     script = [
         "plugin -i systemverilog",
         "tee -o %s/%ssurelog_ast.txt read_systemverilog -dump_ast1 -mutestdout %s" % (output_dir, prefix, test_path),
-        "synth_xilinx",
+        "synth",
         "write_verilog %s/%ssurelog_gate.v" % (output_dir, prefix),
     ]
 
@@ -183,7 +183,7 @@ def run_yosys(test_path, output_dir, prefix=""):
 
     script = [
         "tee -o %s/%syosys_ast.txt read_verilog -dump_ast1 -sv %s" % (output_dir, prefix, test_path),
-        "synth_xilinx",
+        "synth",
         "write_verilog %s/%syosys_gate.v" % (output_dir, prefix),
     ]
 

--- a/formal_verification.py
+++ b/formal_verification.py
@@ -150,6 +150,7 @@ def run_surelog(test_path, output_dir, prefix=""):
     script = [
         "plugin -i systemverilog",
         "tee -o %s/%ssurelog_ast.txt read_systemverilog -dump_ast1 -mutestdout %s" % (output_dir, prefix, test_path),
+        "hierarchy -auto-top",
         "synth",
         "write_verilog %s/%ssurelog_gate.v" % (output_dir, prefix),
     ]
@@ -183,6 +184,7 @@ def run_yosys(test_path, output_dir, prefix=""):
 
     script = [
         "tee -o %s/%syosys_ast.txt read_verilog -dump_ast1 -sv %s" % (output_dir, prefix, test_path),
+        "hierarchy -auto-top",
         "synth",
         "write_verilog %s/%syosys_gate.v" % (output_dir, prefix),
     ]


### PR DESCRIPTION
There are opinions that yosys is better at comparing non-vendor specific synthesis results when doing formal verification. Let's run this and check the results.