### PR TITLE
CI: Speed up `build-binaries`

### DIFF
--- a/.github/scripts/set-up-common-ubuntu-configuration.sh
+++ b/.github/scripts/set-up-common-ubuntu-configuration.sh
@@ -81,3 +81,23 @@ printf '%s\n' \
 end_group
 
 #-----------------------------------------------------------------------------
+begin_group 'Configure git'
+#-----------------------------------------------------------------------------
+
+# Use "some reasonable default" parallel fetch operations.
+# https://git-scm.com/docs/git-config#Documentation/git-config.txt-fetchparallel
+cat >> ~/.gitconfig <<-EOF
+[fetch]
+	parallel=0
+EOF
+# Github dropped support for unauthorized git:
+# https://github.blog/2021-09-01-improving-git-protocol-security-github/
+# Make sure we always use https:// instead of git://
+cat >> ~/.gitconfig <<-EOF
+[url "https://github.com/"]
+	insteadOf=git://github.com/
+EOF
+
+end_group
+
+#-----------------------------------------------------------------------------

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -55,8 +55,15 @@ jobs:
       - name: Extract
         run: tar -xf binaries.tar
 
+      - name: Download sv2v
+        uses: actions/download-artifact@v2
+        with:
+          name: sv2v
+          path: image/bin/
+
       - name: Test
         run: |
+          chmod +x image/bin/sv2v
           source .github/scripts/common.sh
           ./run_fv_tests.sh "$TEST_SUITE" "$TEST_SUITE_NAME"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Checkout submodules
         run: |
-          git submodule update -j 8 --depth 1 --init --recursive \
+          git submodule update --depth 1 --init --recursive \
               Surelog \
               yosys \
               yosys-f4pga-plugins \
@@ -74,7 +74,7 @@ jobs:
         run: |
           cd yosys-f4pga-plugins
           git remote add github/antmicro https://github.com/antmicro/yosys-f4pga-plugins.git
-          git fetch -j 8 github/antmicro ${{github.event.inputs.plugins_branch}}
+          git fetch github/antmicro ${{github.event.inputs.plugins_branch}}
           git checkout FETCH_HEAD
 
       - name: Setup cache
@@ -86,9 +86,6 @@ jobs:
 
       - name: Build binaries
         run: |
-          # Github dropped support for unauthorized git: https://github.blog/2021-09-01-improving-git-protocol-security-github/
-          # Make sure we always use https:// instead of git://
-          git config --global url.https://github.com/.insteadOf git://github.com/
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           ./build_binaries.sh
           # By default actions/upload-artifact@v2 do not preserve file permissions
@@ -152,7 +149,7 @@ jobs:
       - name: Checkout submodules
         if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
         run: |
-          git submodule update -j 8 --depth 1 --init --recursive \
+          git submodule update --depth 1 --init --recursive \
               sv2v \
               ;
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
     container: ubuntu:jammy
     env:
       DEBIAN_FRONTEND: noninteractive
-      GHA_MACHINE_TYPE: "n2-highmem-8"
+      GHA_MACHINE_TYPE: "n2-standard-4"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,6 @@ jobs:
               Surelog \
               yosys \
               yosys-f4pga-plugins \
-              sv2v \
               ;
 
       - name: Checkout custom branches in submodules (if requested)
@@ -91,7 +90,7 @@ jobs:
           # Make sure we always use https:// instead of git://
           git config --global url.https://github.com/.insteadOf git://github.com/
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-          ./build_binaries.sh --build-sv2v
+          ./build_binaries.sh
           # By default actions/upload-artifact@v2 do not preserve file permissions
           # tar directory to workaround this issue
           # See https://github.com/actions/upload-artifact/issues/38
@@ -105,6 +104,83 @@ jobs:
             binaries.tar
 
       - name: Upload load graphs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: plots
+          path: |
+            **/plot_*.svg
+
+  build-sv2v:
+    name: Build sv2v
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:jammy
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      GHA_MACHINE_TYPE: "n2-highmem-8"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - name: Set up common Ubuntu configuration
+        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt install -y git wget
+
+      - name: 'Read submodule revisions'
+        id: rev
+        run: |
+           CACHE_HASH_LENGTH=20
+           repo_hash="$(git submodule status sv2v)"
+           # Skip first character which is ' ' or '+'
+           repo_hash="${repo_hash:1:$CACHE_HASH_LENGTH}"
+           printf '::set-output name=%s::%s\n' 'sv2v-submodule-rev' "${repo_hash}"
+
+      - name: Try restoring build results from cache
+        id: cache-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: image/bin/sv2v
+          key: sv2v@${{ steps.rev.outputs.sv2v-submodule-rev }}
+
+      - name: Checkout submodules
+        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+        run: |
+          git submodule update -j 8 --depth 1 --init --recursive \
+              sv2v \
+              ;
+
+      - name: Build binaries
+        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+        run: |
+          mkdir -p $PWD/image/bin
+          export PATH=$PWD/install/bin:/usr/local/bin:${PATH}
+          wget -qO- https://get.haskellstack.org/ | sh -s - -f -d /usr/local/bin
+          make -j$(nproc --all) -C $PWD/sv2v
+          cp $PWD/sv2v/bin/sv2v image/bin
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v2
+        with:
+          name: sv2v
+          path: |
+            image/bin/sv2v
+
+      - name: Save build results to cache
+        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' && ! (failure() || cancelled()) }}
+        uses: actions/cache/save@v3
+        with:
+          path: image/bin/sv2v
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+
+      - name: Upload load graphs
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v2
         with:
           name: plots
@@ -119,7 +195,9 @@ jobs:
   tests-formal-verification:
     name: Formal Verification Tests
     uses: ./.github/workflows/formal-verification.yml
-    needs: build-binaries
+    needs:
+      - build-binaries
+      - build-sv2v
 
   tests-large-designs:
     name: Large Designs Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
       CCACHE_DIR: "/root/yosys-uhdm-plugin-integration/yosys-uhdm-plugin-integration/.cache/"
       DEBIAN_FRONTEND: noninteractive
       PLUGIN_ASAN: 1
+      GHA_MACHINE_TYPE: "n2-highmem-8"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
+          submodules: false
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -61,12 +61,21 @@ jobs:
         with:
           format: 'YYYY-MM-DD-HH-mm-ss'
 
+      - name: Checkout submodules
+        run: |
+          git submodule update -j 8 --depth 1 --init --recursive \
+              Surelog \
+              yosys \
+              yosys-f4pga-plugins \
+              sv2v \
+              ;
+
       - name: Checkout custom branches in submodules (if requested)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.plugins_branch != ''}}
         run: |
           cd yosys-f4pga-plugins
           git remote add github/antmicro https://github.com/antmicro/yosys-f4pga-plugins.git
-          git fetch github/antmicro ${{github.event.inputs.plugins_branch}}
+          git fetch -j 8 github/antmicro ${{github.event.inputs.plugins_branch}}
           git checkout FETCH_HEAD
 
       - name: Setup cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
           mkdir -p $PWD/image/bin
           export PATH=$PWD/install/bin:/usr/local/bin:${PATH}
           wget -qO- https://get.haskellstack.org/ | sh -s - -f -d /usr/local/bin
-          make -j$(nproc --all) -C $PWD/sv2v
+          make -j$(nproc) -C $PWD/sv2v
           cp $PWD/sv2v/bin/sv2v image/bin
 
       - name: Upload binaries

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -31,13 +31,13 @@ done
 #Surelog
 cd Surelog
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S . -B build
-cmake --build build -j $(nproc --all)
+cmake --build build -j $(nproc)
 cmake --install build
 cd ..
 #Yosys
 if [ "$SKIP_YOSYS" -eq "0" ]; then
 cd yosys
-make CONFIG=gcc PREFIX=$INSTALL_PATH install -j $(nproc --all)
+make CONFIG=gcc PREFIX=$INSTALL_PATH install -j $(nproc)
 cd ..
 fi
 #UHDM plugin
@@ -45,9 +45,9 @@ if [ "$PLUGIN_ASAN" -eq "1" ]; then
   PLUGIN_LDFLAGS="-fsanitize=address -fcheck-new -fno-omit-frame-pointer -static-libasan"
 fi
 export PATH=$INSTALL_PATH/bin:${PATH}
-UHDM_INSTALL_DIR=$INSTALL_PATH LDFLAGS=$PLUGIN_LDFLAGS make -C $PWD/yosys-f4pga-plugins/ install -j$(nproc --all)
+UHDM_INSTALL_DIR=$INSTALL_PATH LDFLAGS=$PLUGIN_LDFLAGS make -C $PWD/yosys-f4pga-plugins/ install -j$(nproc)
 #sv2v
 if [ "$BUILD_SV2V" -eq "1" ]; then
 wget -qO- https://get.haskellstack.org/ | sh -s - -f -d $INSTALL_PATH/bin
-make -j$(nproc --all) -C $PWD/sv2v && cp $PWD/sv2v/bin/sv2v $INSTALL_PATH/bin
+make -j$(nproc) -C $PWD/sv2v && cp $PWD/sv2v/bin/sv2v $INSTALL_PATH/bin
 fi

--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -31,13 +31,13 @@ done
 #Surelog
 cd Surelog
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_PATH -DCMAKE_POSITION_INDEPENDENT_CODE=ON -S . -B build
-cmake --build build -j $(nproc)
+cmake --build build -j $(nproc --all)
 cmake --install build
 cd ..
 #Yosys
 if [ "$SKIP_YOSYS" -eq "0" ]; then
 cd yosys
-make CONFIG=gcc PREFIX=$INSTALL_PATH install -j $(nproc)
+make CONFIG=gcc PREFIX=$INSTALL_PATH install -j $(nproc --all)
 cd ..
 fi
 #UHDM plugin
@@ -45,9 +45,9 @@ if [ "$PLUGIN_ASAN" -eq "1" ]; then
   PLUGIN_LDFLAGS="-fsanitize=address -fcheck-new -fno-omit-frame-pointer -static-libasan"
 fi
 export PATH=$INSTALL_PATH/bin:${PATH}
-UHDM_INSTALL_DIR=$INSTALL_PATH LDFLAGS=$PLUGIN_LDFLAGS make -C $PWD/yosys-f4pga-plugins/ install -j$(nproc)
+UHDM_INSTALL_DIR=$INSTALL_PATH LDFLAGS=$PLUGIN_LDFLAGS make -C $PWD/yosys-f4pga-plugins/ install -j$(nproc --all)
 #sv2v
 if [ "$BUILD_SV2V" -eq "1" ]; then
 wget -qO- https://get.haskellstack.org/ | sh -s - -f -d $INSTALL_PATH/bin
-make -C $PWD/sv2v && cp $PWD/sv2v/bin/sv2v $INSTALL_PATH/bin
+make -j$(nproc --all) -C $PWD/sv2v && cp $PWD/sv2v/bin/sv2v $INSTALL_PATH/bin
 fi


### PR DESCRIPTION
- Use 8-core machine for building
- The job downloads only submodules it needs, i.e. Yosys, Surelog, sv2v, yosys-f4pga-plugins.
- Sv2v building has been moved to its own job.
  - It is used only by formal tests, the rest doesn't need to wait for it.
  - Changes rarely, so the built binary is just cached using git revision as part of the cache key.

Workflow without cached sv2v: https://github.com/antmicro/yosys-systemverilog/actions/runs/4490034124/jobs/7896597216

Overall, in most cases, binaries built time changed from more than 10 min to about 5 min.