### PR TITLE
CI: Use `▌` instead of a timestamp in console output.

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -3,6 +3,9 @@ name: Formal Verification Tests
 on:
   workflow_call:
 
+env:
+  GHA_CUSTOM_LINE_PREFIX: "▌"
+
 jobs:
   tests-formal-verification:
     runs-on: [self-hosted, Linux, X64]
@@ -25,7 +28,6 @@ jobs:
       GIT_HTTP_LOW_SPEED_TIME: 600
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-highmem-8"
-      GHA_CUSTOM_LINE_PREFIX: "▌"
       PARSER: yosys-plugin
       TEST_SUITE_DIR: ${{ matrix.test-suite }}
       TEST_SUITE_NAME: ${{ matrix.name }}

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -25,6 +25,7 @@ jobs:
       GIT_HTTP_LOW_SPEED_TIME: 600
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-highmem-8"
+      GHA_CUSTOM_LINE_PREFIX: "▌"
       PARSER: yosys-plugin
       TEST_SUITE_DIR: ${{ matrix.test-suite }}
       TEST_SUITE_NAME: ${{ matrix.name }}

--- a/.github/workflows/large-designs.yml
+++ b/.github/workflows/large-designs.yml
@@ -139,6 +139,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       GHA_EXTERNAL_DISK: "tools"
       GHA_MACHINE_TYPE: "n2-highmem-8"
+      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - uses: actions/checkout@v3
@@ -230,6 +231,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       GHA_EXTERNAL_DISK: "tools"
       GHA_MACHINE_TYPE: "n2-highmem-32"
+      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - uses: actions/checkout@v3
@@ -303,6 +305,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       GHA_EXTERNAL_DISK: "tools"
       GHA_MACHINE_TYPE: "n2-highmem-32"
+      GHA_CUSTOM_LINE_PREFIX: "▌"
       PARALLEL_JOBS: 32
       # Minimum free RAM (in percents) required to start a test
       MIN_FREE_MEM_TO_START_TEST: 20

--- a/.github/workflows/large-designs.yml
+++ b/.github/workflows/large-designs.yml
@@ -3,6 +3,9 @@ name: Large Designs Tests
 on:
   workflow_call:
 
+env:
+  GHA_CUSTOM_LINE_PREFIX: "▌"
+
 jobs:
   ibex_synth:
     name: Ibex (Vivado synthesis)
@@ -139,7 +142,6 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       GHA_EXTERNAL_DISK: "tools"
       GHA_MACHINE_TYPE: "n2-highmem-8"
-      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - uses: actions/checkout@v3
@@ -231,7 +233,6 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       GHA_EXTERNAL_DISK: "tools"
       GHA_MACHINE_TYPE: "n2-highmem-32"
-      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - uses: actions/checkout@v3
@@ -305,7 +306,6 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       GHA_EXTERNAL_DISK: "tools"
       GHA_MACHINE_TYPE: "n2-highmem-32"
-      GHA_CUSTOM_LINE_PREFIX: "▌"
       PARALLEL_JOBS: 32
       # Minimum free RAM (in percents) required to start a test
       MIN_FREE_MEM_TO_START_TEST: 20

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       PLUGIN_ASAN: 1
       GHA_MACHINE_TYPE: "n2-highmem-8"
+      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - uses: actions/checkout@v3
@@ -115,6 +116,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-standard-4"
+      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - uses: actions/checkout@v3
@@ -282,6 +284,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-standard-2"
+      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - name: Install Yosys and dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ on:
       - master
   pull_request:
 
+env:
+  GHA_CUSTOM_LINE_PREFIX: "▌"
+
 jobs:
   build-binaries:
     name: Build Binaries
@@ -32,7 +35,6 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       PLUGIN_ASAN: 1
       GHA_MACHINE_TYPE: "n2-highmem-8"
-      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - uses: actions/checkout@v3
@@ -116,7 +118,6 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-standard-4"
-      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - uses: actions/checkout@v3
@@ -284,7 +285,6 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-standard-2"
-      GHA_CUSTOM_LINE_PREFIX: "▌"
 
     steps:
       - name: Install Yosys and dependencies

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
 
 env:
+  GHA_CUSTOM_LINE_PREFIX: "▌"
   TESTS_TO_SKIP: ibex swerv synthesis opentitan serv serv-minimal hello-uvm assignment-pattern Forever BitsCallOnType OneClass
     Continue AnonymousUnion ParameterUnpackedArray VoidFunction2Returns PatternStruct ImportedFunctionCallInModuleAndSubmodule
     VoidFunctionWithoutReturn cmake PutC OneThis CastInFunctionInGenBlock PatternType FunctionOutputArgument GetC ForkJoinTypes
@@ -31,7 +32,6 @@ jobs:
       GIT_HTTP_LOW_SPEED_TIME: 600
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-standard-2"
-      GHA_CUSTOM_LINE_PREFIX: "▌"
       PARSER: surelog
 
     steps:
@@ -107,7 +107,6 @@ jobs:
       GIT_HTTP_LOW_SPEED_TIME: 600
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-standard-2"
-      GHA_CUSTOM_LINE_PREFIX: "▌"
       PARSER: yosys-plugin
 
     steps:

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -31,6 +31,7 @@ jobs:
       GIT_HTTP_LOW_SPEED_TIME: 600
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-standard-2"
+      GHA_CUSTOM_LINE_PREFIX: "▌"
       PARSER: surelog
 
     steps:
@@ -106,6 +107,7 @@ jobs:
       GIT_HTTP_LOW_SPEED_TIME: 600
       DEBIAN_FRONTEND: noninteractive
       GHA_MACHINE_TYPE: "n2-standard-2"
+      GHA_CUSTOM_LINE_PREFIX: "▌"
       PARSER: yosys-plugin
 
     steps:

--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+env:
+  GHA_CUSTOM_LINE_PREFIX: "▌"
+
 jobs:
   test-plugin-from-sources:
     runs-on: [self-hosted, Linux, X64]


### PR DESCRIPTION
The Github itself offers an option to show timestamps on demand, and they are always present in log dumps. The only added value of the Runner-generated timestamp has been indication (with a color) whether the line has been printed to the stdout or the stderr. A single `▌` does this job as well, and leaves more horizontal space for actual content.

The option to show timestamps is in the gear menu:
![Screenshot_20230417_130444](https://user-images.githubusercontent.com/4888536/232467042-aa5f9d1e-2d01-4317-8c9c-37ef542e87cd.png)

View "main" CI logs for this PR to see an example, e.g. https://github.com/antmicro/yosys-systemverilog/actions/runs/4720484169/jobs/8372587488#step:5:2