### PR TITLE
CI: run pinned opentitan synth only on main branch

### DIFF
--- a/.github/workflows/large-designs.yml
+++ b/.github/workflows/large-designs.yml
@@ -136,6 +136,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     # vivado is linked with libraries used in this version of ubuntu
     container: ubuntu:jammy
+    if: ${{github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')}}
     env:
       CC: gcc-9
       CXX: g++-9


### PR DESCRIPTION
This job takes more than 4h to complete. We are also testing another opentitan version in PR CI.