### PR TITLE
CI: Fetch only required submodules.

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -35,7 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -47,7 +46,15 @@ jobs:
           apt install -y software-properties-common
           add-apt-repository ppa:ubuntu-toolchain-r/test
           apt-get update -qq
-          apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev time python3 jq
+          apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev time python3 jq git
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              yosys \
+              sv2v \
+              UHDM-integration-tests \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2

--- a/.github/workflows/large-designs.yml
+++ b/.github/workflows/large-designs.yml
@@ -20,7 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -35,6 +34,14 @@ jobs:
           apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip libtinfo5
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              UHDM-integration-tests \
+              uhdm-tests/ibex/make-env \
+              uhdm-tests/ibex/ibex \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2
@@ -81,7 +88,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -96,6 +102,14 @@ jobs:
           apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip wget
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              UHDM-integration-tests \
+              uhdm-tests/ibex/make-env \
+              uhdm-tests/ibex/ibex \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2
@@ -147,7 +161,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -162,6 +175,13 @@ jobs:
           apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip libtinfo5
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              UHDM-integration-tests \
+              uhdm-tests/opentitan/opentitan-9d82960888 \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2
@@ -238,7 +258,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -253,6 +272,13 @@ jobs:
           apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip libtinfo5
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              UHDM-integration-tests \
+              uhdm-tests/opentitan/opentitan \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2
@@ -314,7 +340,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -331,10 +356,12 @@ jobs:
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
           pip install virtualenv
 
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-          fetch-depth: 1
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              UHDM-integration-tests \
+              uhdm-tests/opentitan/opentitan \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2
@@ -407,7 +434,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -422,6 +448,13 @@ jobs:
           apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              UHDM-integration-tests \
+              uhdm-tests/swerv/Cores-SweRV \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2
@@ -465,7 +498,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -480,6 +512,17 @@ jobs:
           apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              UHDM-integration-tests \
+              uhdm-tests/black-parrot/black-parrot \
+              ;
+          git submodule update --depth 1 --init \
+              uhdm-tests/black-parrot/black-parrot-tools \
+              uhdm-tests/black-parrot/black-parrot-sdk \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -37,7 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -49,8 +48,15 @@ jobs:
           apt install -y software-properties-common
           add-apt-repository ppa:ubuntu-toolchain-r/test
           apt-get update -qq
-          apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+          apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              Surelog \
+              UHDM-integration-tests \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2
@@ -112,7 +118,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -124,8 +129,15 @@ jobs:
           apt install -y software-properties-common
           add-apt-repository ppa:ubuntu-toolchain-r/test
           apt-get update -qq
-          apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+          apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive \
+              Surelog \
+              UHDM-integration-tests \
+              ;
 
       - name: Download binaries
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Black-parrot SDK has really huge submodules (buildroot, linux kernel, yocto) which we don't use. Fetching of those submodules added a few minutes to each CI job.

Instead of always recursively fetching everything, each job now pulls only submodules it needs.

Checkout (+ "Checkout submodules") durations before and after:

| Job                             | Checkout before | Checkout after |
|---------------------------------|-----------------|----------------|
| parsing/*                       |           04:52 |          00:31 |
| formal verification/*           |           04:59 |          00:12 |
| large designs/ibex              |           05:00 |          00:16 |
| large designs/opentitan (synth) |           04:48 |          00:11 |
| large designs/opentitan parsing |           04:54 |          00:20 |
| large designs/swerv             |           04:54 |          00:03 |
| large designs/black parrot      |           04:52 |          00:29 |