### PR TITLE
Install pkg-config and libcairo2-dev for ibex_synth job

### DIFF
--- a/.github/workflows/large-designs.yml
+++ b/.github/workflows/large-designs.yml
@@ -31,7 +31,7 @@ jobs:
           apt install -y software-properties-common
           add-apt-repository ppa:ubuntu-toolchain-r/test
           apt-get update -qq
-          apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip libtinfo5
+          apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip libtinfo5 pkg-config libcairo2-dev
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 


### PR DESCRIPTION
Ibex Vivado synthesis started failing because of missing packages. Here's an example job that failed: https://github.com/antmicro/yosys-systemverilog/actions/runs/4891230300/jobs/8735612232. This PR adds these packages.