### PR TITLE
CI: Add support for workflow_dispatch with external custom submodules

### DIFF
--- a/.github/scripts/submodule-revision-override.inc.bash
+++ b/.github/scripts/submodule-revision-override.inc.bash
@@ -28,6 +28,89 @@ parse-custom-branch-spec() {
 }
 
 
+html-escape() {
+	local v="$1"
+	v="${v//&/\&amp;}"
+	v="${v//</\&lt;}"
+	v="${v//>/\&gt;}"
+	v="${v//\"/\&quot;}"
+	v="${v//\'/\&apos;}"
+	printf '%s\n' "$v"
+}
+
+
+quot-escape() {
+	local v="$1"
+	v="${v//\\/\\\\}"
+	v="${v//\"/\\\"}"
+	v="${v//\'/\\\'}"
+	printf '%s\n' "$v"
+}
+
+
+# Prints info inteded to be written to `$GITHUB_STEP_SUMMARY`. See main.yml.
+emit-custom-branch-info-entry() {
+	local -r submodule_name="$1"
+	local -r default_gh_user="$2"
+	local -r default_gh_repo="$3"
+	local -r branch_spec="$4"
+
+	local gh_branch=
+	local gh_url=
+	local gh_repo_url=
+	local gh_rev=
+	local override_str=
+
+	if [[ -n "$branch_spec" ]]; then
+		local gh_user="$default_gh_user"
+		local gh_repo="$default_gh_repo"
+		gh_branch="$branch_spec"
+		# Parse Github branch URL name and store respective values in passed `gh_*` variables.
+		# It does not touch the variables if the `branch_spec` is not an URL nor does start with `/`.
+		parse-custom-branch-spec gh_user gh_repo gh_branch "$branch_spec"
+
+		gh_repo_url="https://github.com/${gh_user}/${gh_repo}.git"
+		# Query the repo and get branch's revision.
+		gh_rev="$(git ls-remote -q "$gh_repo_url" "$gh_branch" 2>/dev/null | head -n1 | cut -f 1)"
+		if [[ -z "$gh_rev" && "$gh_branch" =~ ^[0-9a-fA-F]{40}$ ]]; then
+			# If the "branch" is not found in the repo and it looks like a revision hash, assume it is a revision hash.
+			gh_rev="$gh_branch"
+			gh_branch=''
+		fi
+		# URL to the revision Github page.
+		gh_url="https://github.com/${gh_user}/${gh_repo}/tree/${gh_rev}"
+		override_str=' (override)'
+	else
+		# No custom branch. For simplicity `gh_url` is left empty. It is not that useful in this case anyway.
+		# Read submodule URL and revision.
+		gh_repo_url="$(git config --file=.gitmodules submodule."$submodule_name".url)"
+		gh_rev="$(git submodule status "$submodule_name" 2>/dev/null | cut -b 2-41)"
+	fi
+
+	local gh_info="<samp>${gh_rev}</samp>"
+	if [[ -n "$gh_url" ]]; then
+		gh_info="<a href='$(quot-escape "${gh_url}")'>${gh_info}</a>"
+	fi
+	if [[ -n "$gh_branch" ]]; then
+		gh_info="${gh_info} (<samp>$(html-escape "${gh_branch}")</samp>)"
+	fi
+	printf '<dt>%s%s</dt><dd>%s<br><samp>%s</samp></dd>\n' \
+			"$(html-escape "$submodule_name")" "$override_str" \
+			"${gh_info}" \
+			"$(html-escape "${gh_repo_url}")"
+}
+
+
+emit-custom-branch-info-begin() {
+	printf '<dl>\n'
+}
+
+
+emit-custom-branch-info-end() {
+	printf '</dl>\n'
+}
+
+
 # override-submodule-if-requested SUBMODULE_NAME DEFAULT_GH_USER DEFAULT_GH_REPO BRANCH_SPEC
 #
 # Parses Github revision (tree) URL or a revision passed in `BRANCH_SPEC` and

--- a/.github/scripts/submodule-revision-override.inc.bash
+++ b/.github/scripts/submodule-revision-override.inc.bash
@@ -1,0 +1,68 @@
+# Defaults
+declare -r yosys_f4pga_plugins_default_gh_user=antmicro
+declare -r yosys_f4pga_plugins_default_gh_repo=yosys-f4pga-plugins
+
+
+# parse-custom-branch-spec USER_OUT_VAR_NAME REPO_OUT_VAR_NAME BRANCH_OUT_VAR_NAME BRANCH_SPEC
+#
+# Parses Github revision (tree) URL passed in `BRANCH_SPEC` and writes
+# user name, repo name, and revision, to respective variables passed in
+# `*_OUT_VAR_NAME` arguments.
+#
+# The `BRANCH_SPEC` can skip `https://github.com` prefix, but has to keep `/` as
+# a first character.
+#
+# Note: `*_OUT_VAR_NAME` shall not start with `_`.
+parse-custom-branch-spec() {
+	local -n _user_out="$1"
+	local -n _repo_out="$2"
+	local -n _branch_out="$3"
+	local -r _branch_spec="$4"
+	if [[ "$_branch_spec" =~ (https?://github.com)?/([^/]+)/([^/]+)/tree/(.+) ]]; then
+		_user_out="${BASH_REMATCH[2]}"
+		_repo_out="${BASH_REMATCH[3]}"
+		_branch_out="${BASH_REMATCH[4]}"
+	fi
+}
+
+
+# override-submodule-if-requested SUBMODULE_NAME DEFAULT_GH_USER DEFAULT_GH_REPO BRANCH_SPEC
+#
+# Parses Github revision (tree) URL or a revision passed in `BRANCH_SPEC` and
+# switches `SUBMODULE_NAME` submodule to use that revision. If the `BRANCH_SPEC`
+# contains just a revision, `DEFAULT_GH_USER` and `DEFAULT_GH_REPO` are used to
+# locate that revision.
+#
+# The URL has to be in form:
+#     https://github.com/<USER>/<REPO>/tree/<REVISION>
+# or just:
+#     /<USER>/<REPO>/tree/<REVISION>
+# to be considered an URL.
+#
+# When `BRANCH_SPEC` is empty nothing is changed.
+override-submodule-if-requested() {
+	local -r submodule_name="$1"
+	local -r default_gh_user="$2"
+	local -r default_gh_repo="$3"
+	local -r branch_spec="$4"
+
+	local gh_user="$default_gh_user"
+	local gh_repo="$default_gh_repo"
+	local gh_branch="$branch_spec"
+
+	# Parse Github branch URL and store respective values in passed `gh_*` variables.
+	parse-custom-branch-spec \
+			gh_user gh_repo gh_branch \
+			"$branch_spec"
+
+	printf '%s: %s\n' \
+			'user	' "$gh_user" \
+			'repo	' "$gh_repo" \
+			'branch' "$gh_branch" \
+			;
+
+	cd "$submodule_name"
+	git remote add custom "https://github.com/${gh_user}/${gh_repo}.git"
+	git fetch custom "${gh_branch}"
+	git checkout FETCH_HEAD
+}

--- a/.github/scripts/submodule-revision-override.inc.bash
+++ b/.github/scripts/submodule-revision-override.inc.bash
@@ -1,6 +1,8 @@
 # Defaults
 declare -r yosys_f4pga_plugins_default_gh_user=antmicro
 declare -r yosys_f4pga_plugins_default_gh_repo=yosys-f4pga-plugins
+declare -r uhdm_tests_default_gh_user=antmicro
+declare -r uhdm_tests_default_gh_repo=uhdm-integration
 
 
 # parse-custom-branch-spec USER_OUT_VAR_NAME REPO_OUT_VAR_NAME BRANCH_OUT_VAR_NAME BRANCH_SPEC

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -2,6 +2,12 @@ name: Formal Verification Tests
 
 on:
   workflow_call:
+    inputs:
+      uhdm_tests_branch:
+        description: 'UHDM-integration-tests branch or URL'
+        required: false
+        type: 'string'
+        default: ''
 
 env:
   GHA_CUSTOM_LINE_PREFIX: "▌"
@@ -55,6 +61,18 @@ jobs:
               sv2v \
               UHDM-integration-tests \
               ;
+
+      - name: Override submodule revisions (if requested)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.uhdm_tests_branch != ''}}
+        env:
+          UHDM_TESTS_BRANCH_SPEC: ${{github.event.inputs.uhdm_tests_branch}}
+        run: |
+          source ./.github/scripts/submodule-revision-override.inc.bash
+
+          override-submodule-if-requested \
+              'UHDM-integration-tests' \
+              "$uhdm_tests_default_gh_user" "$uhdm_tests_default_gh_repo" \
+              "$UHDM_TESTS_BRANCH_SPEC"
 
       - name: Download binaries
         uses: actions/download-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,37 @@ env:
   GHA_CUSTOM_LINE_PREFIX: "▌"
 
 jobs:
+  emit-workflow-info:
+    name: Emit Workflow Info
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: [self-hosted, Linux, X64]
+    container: 'bitnami/git:2.40.1-debian-11-r4'
+    env:
+      PLUGINS_BRANCH_SPEC: ${{github.event.inputs.plugins_branch}}
+      UHDM_TESTS_BRANCH_SPEC: ${{github.event.inputs.uhdm_tests_branch}}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: false
+          fetch-depth: 1
+
+      - run: |
+          source ./.github/scripts/submodule-revision-override.inc.bash
+
+          {
+            emit-custom-branch-info-begin
+            emit-custom-branch-info-entry \
+                'yosys-f4pga-plugins' \
+                "$yosys_f4pga_plugins_default_gh_user" "$yosys_f4pga_plugins_default_gh_repo" \
+                "$PLUGINS_BRANCH_SPEC"
+            emit-custom-branch-info-entry \
+                'UHDM-integration-tests' \
+                "$uhdm_tests_default_gh_user" "$uhdm_tests_default_gh_repo" \
+                "$UHDM_TESTS_BRANCH_SPEC"
+            emit-custom-branch-info-end
+          } > $GITHUB_STEP_SUMMARY
+
   build-binaries:
     name: Build Binaries
     runs-on: [self-hosted, Linux, X64]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       plugins_branch:
-        description: 'yosys-f4pga-plugins branch'
+        description: 'yosys-f4pga-plugins branch or URL'
         required: false
         default: ''
   push:
@@ -72,13 +72,17 @@ jobs:
               yosys-f4pga-plugins \
               ;
 
-      - name: Checkout custom branches in submodules (if requested)
+      - name: Override submodule revisions (if requested)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.plugins_branch != ''}}
+        env:
+          PLUGINS_BRANCH_SPEC: ${{github.event.inputs.plugins_branch}}
         run: |
-          cd yosys-f4pga-plugins
-          git remote add github/antmicro https://github.com/antmicro/yosys-f4pga-plugins.git
-          git fetch github/antmicro ${{github.event.inputs.plugins_branch}}
-          git checkout FETCH_HEAD
+          source ./.github/scripts/submodule-revision-override.inc.bash
+
+          override-submodule-if-requested \
+              'yosys-f4pga-plugins' \
+              "$yosys_f4pga_plugins_default_gh_user" "$yosys_f4pga_plugins_default_gh_repo" \
+              "$PLUGINS_BRANCH_SPEC"
 
       - name: Setup cache
         uses: actions/cache@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,24 @@
 name: 'main'
 run-name: >
   ${{ github.event_name == 'workflow_dispatch' &&
-        format('{0}{1}',
+        format('{0}{1}{2}',
           github.ref_name,
-          (github.event.inputs.plugins_branch && format('; plugins: {0}', github.event.inputs.plugins_branch) || '')
+          (github.event.inputs.plugins_branch && format( '; plugins: {0}', github.event.inputs.plugins_branch ) || ''),
+          (github.event.inputs.uhdm_tests_branch && format( '; uhdm_tests: {0}', github.event.inputs.uhdm_tests_branch ) || '')
         )
       || ''
   }}
+
 
 on:
   workflow_dispatch:
     inputs:
       plugins_branch:
         description: 'yosys-f4pga-plugins branch or URL'
+        required: false
+        default: ''
+      uhdm_tests_branch:
+        description: 'UHDM-integration-tests branch or URL'
         required: false
         default: ''
   push:
@@ -194,11 +200,15 @@ jobs:
   tests-parsing:
     name: Parsing Tests
     uses: ./.github/workflows/parsing-tests.yml
+    with:
+      uhdm_tests_branch: ${{github.event.inputs.uhdm_tests_branch}}
     needs: build-binaries
 
   tests-formal-verification:
     name: Formal Verification Tests
     uses: ./.github/workflows/formal-verification.yml
+    with:
+      uhdm_tests_branch: ${{github.event.inputs.uhdm_tests_branch}}
     needs:
       - build-binaries
       - build-sv2v

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -2,6 +2,12 @@ name: Parsing Tests
 
 on:
   workflow_call:
+    inputs:
+      uhdm_tests_branch:
+        description: 'UHDM-integration-tests branch or URL'
+        required: false
+        type: 'string'
+        default: ''
 
 env:
   GHA_CUSTOM_LINE_PREFIX: "▌"
@@ -58,6 +64,18 @@ jobs:
               Surelog \
               UHDM-integration-tests \
               ;
+
+      - name: Override submodule revisions (if requested)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.uhdm_tests_branch != ''}}
+        env:
+          UHDM_TESTS_BRANCH_SPEC: ${{github.event.inputs.uhdm_tests_branch}}
+        run: |
+          source ./.github/scripts/submodule-revision-override.inc.bash
+
+          override-submodule-if-requested \
+              'UHDM-integration-tests' \
+              "$uhdm_tests_default_gh_user" "$uhdm_tests_default_gh_repo" \
+              "$UHDM_TESTS_BRANCH_SPEC"
 
       - name: Download binaries
         uses: actions/download-artifact@v2
@@ -139,6 +157,18 @@ jobs:
               Surelog \
               UHDM-integration-tests \
               ;
+
+      - name: Override submodule revisions (if requested)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.uhdm_tests_branch != ''}}
+        env:
+          UHDM_TESTS_BRANCH_SPEC: ${{github.event.inputs.uhdm_tests_branch}}
+        run: |
+          source ./.github/scripts/submodule-revision-override.inc.bash
+
+          override-submodule-if-requested \
+              'UHDM-integration-tests' \
+              "$uhdm_tests_default_gh_user" "$uhdm_tests_default_gh_repo" \
+              "$UHDM_TESTS_BRANCH_SPEC"
 
       - name: Download binaries
         uses: actions/download-artifact@v2

--- a/README.rst
+++ b/README.rst
@@ -191,22 +191,25 @@ Start a workflow manually (using Github CLI)
 
    gh workflow run main --ref $YOUR_BRANCH_NAME
 
-Using plugins submodule override
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Overriding plugins and UHDM-integration-tests submodule revisions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This method can be used to test changes limited to `yosys-f4pga-plugins` submodule.
+This method can be used to test changes limited to `yosys-f4pga-plugins` or `UHDM-integration-tests` submodules.
 
 - Perform steps from "Start a workflow manually (using Github Web UI)" above, but:
 
   - Select "master" (or any other branch with submodule revisions you would like to use in the CI) in the "Use workflow from" dropdown.
   - In the same pop-up, under "yosys-f4pga-plugins branch or URL", type the name of the branch from https://github.com/antmicro/yosys-f4pga-plugins/, or a Github URL to a revision (in the form `https://github.com/<USER>/<REPO>/tree/<REVISION>`) from any repository. The typed value can skip `https://github.com` prefix (but not the `/`). The passed revision will be checked out in `yosys-f4pga-plugins` submodule.
+    "UHDM-integration-tests branch or URL" field works in the same way.
 
 - Alternatively, use Github CLI:
 
   .. code-block:: bash
      :name: gh-cli-start-workflow-with-plugins-branch
 
-     gh workflow run main --ref master -f plugins_branch=$PLUGINS_BRANCH_NAME_OR_URL
+     gh workflow run main --ref master \
+             -f plugins_branch=$PLUGINS_BRANCH_NAME_OR_URL \
+             -f uhdm_tests_branch=$UHDM_TESTS_BRANCH_NAME_OR_URL
 
 Testing locally
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -196,18 +196,17 @@ Using plugins submodule override
 
 This method can be used to test changes limited to `yosys-f4pga-plugins` submodule.
 
-- Push your changes in `yosys-f4pga-plugins` into a branch in https://github.com/antmicro/yosys-f4pga-plugins/
 - Perform steps from "Start a workflow manually (using Github Web UI)" above, but:
 
   - Select "master" (or any other branch with submodule revisions you would like to use in the CI) in the "Use workflow from" dropdown.
-  - In the same pop-up, under "yosys-f4pga-plugins branch", type the name of the branch from https://github.com/antmicro/yosys-f4pga-plugins/. This branch will be checked out in `yosys-f4pga-plugins` submodule.
+  - In the same pop-up, under "yosys-f4pga-plugins branch or URL", type the name of the branch from https://github.com/antmicro/yosys-f4pga-plugins/, or a Github URL to a revision (in the form `https://github.com/<USER>/<REPO>/tree/<REVISION>`) from any repository. The typed value can skip `https://github.com` prefix (but not the `/`). The passed revision will be checked out in `yosys-f4pga-plugins` submodule.
 
 - Alternatively, use Github CLI:
 
   .. code-block:: bash
      :name: gh-cli-start-workflow-with-plugins-branch
 
-     gh workflow run main --ref master -f plugins_branch=$PLUGINS_BRANCH_NAME
+     gh workflow run main --ref master -f plugins_branch=$PLUGINS_BRANCH_NAME_OR_URL
 
 Testing locally
 ---------------


### PR DESCRIPTION
## Support for custom UHDM-integration-tests branch

`uhdm_tests_branch` can be used in the same way as `plugins_branch` to specify submodule override for UHDM-integration tests.

## Support for branches from any GH repository

The `plugins_branch` and `uhdm_tests_branch` support 3 formats:

- `<REVISION>` - already known, uses `<REVISION>` from Antmicro's fork.
- `https://github.com/<USER>/<REPO>/tree/<REVISION>`
- `/<USER>/<REPO>/tree/<REVISION>` (note `/` at the beginning)

The new formats aren't random - this is an URL of a revision file view. This is where GH points to after clicking "Browse files" button in commits, selecting a branch in a drop-down, or clicking branch name under PR title.

Example: https://github.com/chipsalliance/yosys-f4pga-plugins/tree/a08c529a86a525fc4278221a5599a2e783c8105e

## Workflow info summary panel

Shows exactly what revisions of plugins and tests were used in the workflow:

![Screenshot_20230515_181315](https://github.com/antmicro/yosys-systemverilog/assets/4888536/dc2a8ed9-eae1-4cc8-b9bf-3afe5038f4d7)

## Test results

Please ignore actual job errors, I've picked random revisions. What parameters were passed to each workflow can be seen in the workflow title.

https://github.com/antmicro/yosys-systemverilog/actions/runs/4949458553
https://github.com/antmicro/yosys-systemverilog/actions/runs/4949459157
https://github.com/antmicro/yosys-systemverilog/actions/runs/4949459795
https://github.com/antmicro/yosys-systemverilog/actions/runs/4949460509
https://github.com/antmicro/yosys-systemverilog/actions/runs/4949460939
https://github.com/antmicro/yosys-systemverilog/actions/runs/4949461523