### PR TITLE
CI: reduce submodules checkout time in tuttest jobs

### DIFF
--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Prepare Repository
         uses: actions/checkout@v2
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -58,7 +57,6 @@ jobs:
       - name: Prepare Repository
         uses: actions/checkout@v2
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Set up common Ubuntu configuration
@@ -69,6 +67,10 @@ jobs:
           apt-get update -qq
           apt-get install -y python3-pip git
           pip3 install git+https://github.com/antmicro/tuttest#egg=tuttest
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive yosys-f4pga-plugins
 
       - name: Install Dependencies
         run: |
@@ -99,13 +101,17 @@ jobs:
       - name: Prepare Repository
         uses: actions/checkout@v2
         with:
-          submodules: recursive
+          fetch-depth: 1
 
       - name: Install Prerequisites
         run: |
           apt-get update -qq
           apt-get install -y pipx git
           pipx install git+https://github.com/antmicro/tuttest#egg=tuttest
+
+      - name: Checkout submodules
+        run: |
+          git submodule update --depth 1 --init --recursive yosys-f4pga-plugins
 
       - name: Install Dependencies
         run: |

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ You can build all required binaries using provided ``build_binaries.sh`` script.
    :name: build-binaries
 
    #Make sure submodules are inited and updated to the latest version
-   git submodule update --init --recursive
+   git submodule update --init --recursive Surelog yosys yosys-f4pga-plugins UHDM-integration-tests
    ./build_binaries.sh
 
 To use yosys built from a submodule, make sure to either use absolute paths, or update the ``PATH`` variable before use.


### PR DESCRIPTION
Similar thing that was done in: https://github.com/antmicro/yosys-systemverilog/pull/1674 but this time for tuttest jobs.