### PR TITLE
CI: add job storing AST results in different repository

### DIFF
--- a/.github/scripts/push_to_another_repository.sh
+++ b/.github/scripts/push_to_another_repository.sh
@@ -1,0 +1,64 @@
+#/usr/bin/env bash
+
+set -e -u -o pipefail
+shopt -s nullglob
+
+declare -r SELF_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))"
+declare -r REPO_DIR=$SELF_DIR/../..
+cd $REPO_DIR
+
+REPOSITORY_OWNER="$1"
+PUSH_BRANCH="$2"
+GITHUB_RUN_ID="$3"
+SOURCE_DIRECTORY="$4"
+# for future
+TARGET_DIRECTORY=""
+
+# Inspired by: https://github.com/cpina/github-action-push-to-another-repository/blob/main/entrypoint.sh
+mkdir --parents "$HOME/.ssh"
+DEPLOY_KEY_FILE="$HOME/.ssh/deploy_key"
+echo "${SSH_DEPLOY_KEY}" > "$DEPLOY_KEY_FILE"
+chmod 600 "$DEPLOY_KEY_FILE"
+SSH_KNOWN_HOSTS_FILE="$HOME/.ssh/known_hosts"
+ssh-keyscan -H "github.com" > "$SSH_KNOWN_HOSTS_FILE"
+export GIT_SSH_COMMAND="ssh -i "$DEPLOY_KEY_FILE" -o UserKnownHostsFile=$SSH_KNOWN_HOSTS_FILE"
+GIT_CMD_REPOSITORY="git@github.com:$REPOSITORY_OWNER/yosys-systemverilog-logs.git"
+CLONE_DIR=$(mktemp -d)
+git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git config --global user.name "github-actions[bot]"
+{
+    git clone --single-branch --depth 1 --branch "$PUSH_BRANCH" "$GIT_CMD_REPOSITORY" "$CLONE_DIR"
+} || {
+    # Default branch of the repository is cloned. Later on the required branch
+    # will be created
+    git clone --single-branch --depth 1 "$GIT_CMD_REPOSITORY" "$CLONE_DIR"
+} || {
+    echo "::error::Could not clone the destination repository. Command:"
+    echo "::error::git clone --single-branch --branch $PUSH_BRANCH $GIT_CMD_REPOSITORY $CLONE_DIR"
+    echo "::error::(Note that if they exist USER_NAME and API_TOKEN is redacted by GitHub)"
+    echo "::error::Please verify that the target repository exist AND that it contains the destination branch name, and is accesible by the SSH_DEPLOY_KEY"
+    exit 1
+}
+echo "Current remote files"
+ls -la "$CLONE_DIR"
+TEMP_DIR=$(mktemp -d)
+mv "$CLONE_DIR/.git" "$TEMP_DIR/.git"
+ABSOLUTE_TARGET_DIRECTORY="$CLONE_DIR/$TARGET_DIRECTORY/"
+rm -rf "$ABSOLUTE_TARGET_DIRECTORY"
+mkdir -p "$ABSOLUTE_TARGET_DIRECTORY"
+mv "$TEMP_DIR/.git" "$CLONE_DIR/.git"
+echo "New files"
+ls -la "$SOURCE_DIRECTORY"
+cp -ra "$SOURCE_DIRECTORY"/. "$CLONE_DIR/$TARGET_DIRECTORY"
+cd "$CLONE_DIR"
+echo "Files that will be pushed"
+ls -la
+COMMIT_MESSAGE="Update logs from ORIGIN_COMMIT"
+ORIGIN_COMMIT="https://github.com/$REPOSITORY_OWNER/yosys-systemverilog/actions/runs/$GITHUB_RUN_ID"
+COMMIT_MESSAGE="${COMMIT_MESSAGE/ORIGIN_COMMIT/$ORIGIN_COMMIT}"
+COMMIT_MESSAGE="${COMMIT_MESSAGE/\$GITHUB_REF/$GITHUB_REF}"
+git switch -c "$PUSH_BRANCH" || true
+git add .
+git status
+git diff-index --quiet HEAD || git commit --message "$COMMIT_MESSAGE"
+git push "$GIT_CMD_REPOSITORY" --set-upstream "$PUSH_BRANCH"

--- a/.github/scripts/run_group_test.sh
+++ b/.github/scripts/run_group_test.sh
@@ -17,7 +17,11 @@ do
     export TEST_CASE
     mkdir -p $LOG_DIR/$TEST_CASE
     ROOT_DIR_ABSOLUTE=$(realpath $ROOT_DIR)/
-    $ROOT_DIR/UHDM-integration-tests/.github/ci.sh | sed -e 's#'${ROOT_DIR_ABSOLUTE}'##g' | sed -e 's/\(End of script\).*//' | sed -e 's/\(Time spent\).*//' | tee $LOG_DIR/$TEST_CASE/ast.log
+    $ROOT_DIR/UHDM-integration-tests/.github/ci.sh \
+        | sed -e "s#${ROOT_DIR_ABSOLUTE}##g" \
+            -e 's/\(End of script\).*//' \
+            -e 's/\(Time spent\).*//' \
+                | tee $LOG_DIR/$TEST_CASE/ast.log
     TEST_RET=$?
     TEST_CASE="${TEST_CASE//tests\//}"
     if [[ $TEST_RET -eq 0 ]]; then

--- a/.github/scripts/run_group_test.sh
+++ b/.github/scripts/run_group_test.sh
@@ -7,11 +7,17 @@ else
 fi
 TEST_CASES=$(echo $TEST_CASES | sed "s/[][,\"]//g") # Remove characters '[', ']', '"' and ',' from json like array
 
+LOG_DIR=$ROOT_DIR/logs
+
+mkdir -p $LOG_DIR
+
 mkdir -p $ROOT_DIR/test-results
 for TEST_CASE in $TEST_CASES;
 do
     export TEST_CASE
-    $ROOT_DIR/UHDM-integration-tests/.github/ci.sh
+    mkdir -p $LOG_DIR/$TEST_CASE
+    ROOT_DIR_ABSOLUTE=$(realpath $ROOT_DIR)/
+    $ROOT_DIR/UHDM-integration-tests/.github/ci.sh | sed -e 's#'${ROOT_DIR_ABSOLUTE}'##g' | sed -e 's/\(End of script\).*//' | sed -e 's/\(Time spent\).*//' | tee $LOG_DIR/$TEST_CASE/ast.log
     TEST_RET=$?
     TEST_CASE="${TEST_CASE//tests\//}"
     if [[ $TEST_RET -eq 0 ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -251,8 +251,13 @@ jobs:
   tests-parsing:
     name: Parsing Tests
     uses: ./.github/workflows/parsing-tests.yml
+    secrets:
+      SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+    permissions:
+      pull-requests: write
     with:
       uhdm_tests_branch: ${{github.event.inputs.uhdm_tests_branch}}
+      plugins_branch: ${{github.event.inputs.plugins_branch}}
     needs: build-binaries
 
   tests-formal-verification:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GHA_CUSTOM_LINE_PREFIX: "▌"
 

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -8,6 +8,16 @@ on:
         required: false
         type: 'string'
         default: ''
+      plugins_branch:
+        description: 'yosys-f4pga-plugins branch or URL'
+        required: false
+        type: 'string'
+        default: ''
+    secrets:
+      SSH_DEPLOY_KEY:
+        description: 'SSH key used to push logs'
+        required: true
+
 
 env:
   GHA_CUSTOM_LINE_PREFIX: "▌"
@@ -193,6 +203,11 @@ jobs:
           mv test-results/test-results.failed test-results/test-results-systemverilog.failed || true
 
       - uses: actions/upload-artifact@v3
+        with:
+          name: parsing-logs
+          path: logs
+
+      - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: test-results
@@ -205,6 +220,67 @@ jobs:
           name: plots
           path: |
             **/plot_*.svg
+
+  push-logs:
+    name: Generate AST diff
+    runs-on: ubuntu-latest
+    needs:
+      - tests-read-systemverilog
+    steps:
+      - name: Download test results
+        uses: /actions/download-artifact@v3
+        with:
+          name: parsing-logs
+          path: logs
+      - name: Push branch
+        run: |
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          PUSH_BRANCH=$branch
+          if [[ ! -z "$PLUGINS_BRANCH_SPEC" ]]; then
+            PUSH_BRANCH="$PUSH_BRANCH+plugins+$PLUGINS_BRANCH_SPEC"
+          fi
+          if [[ ! -z "$UHDM_TESTS_BRANCH_SPEC" ]]; then
+            PUSH_BRANCH="$PUSH_BRANCH+tests+$UHDM_TESTS_BRANCH_SPEC"
+          fi
+          echo "PUSH_BRANCH=$PUSH_BRANCH" >> "$GITHUB_ENV"
+          COMMENT_MSG="Logs difference between main branch: https://github.com/${{ github.repository }}-logs/compare/$PUSH_BRANCH"
+          echo "COMMENT_MSG=$COMMENT_MSG" >> "$GITHUB_ENV"
+          PUSH_LOGS=false
+          # currently pushing logs when submodules are overriten using url is not supported
+          if [[ ! "$PLUGINS_BRANCH_SPEC" =~ "https://" && ! "$UHDM_TESTS_BRANCH_SPEC" =~ "https://" ]]; then
+            PUSH_LOGS=true
+          fi
+          echo "PUSH_LOGS=$PUSH_LOGS" >> "$GITHUB_ENV"
+        env:
+          PLUGINS_BRANCH_SPEC: ${{github.event.inputs.plugins_branch}}
+          UHDM_TESTS_BRANCH_SPEC: ${{github.event.inputs.uhdm_tests_branch}}
+
+      - name: Push logs
+        uses: cpina/github-action-push-to-another-repository@main
+        if: ${{ env.PUSH_LOGS == 'true' }}
+        env:
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: 'logs'
+          destination-github-username: ${{ github.repository_owner }}
+          destination-repository-name: 'yosys-systemverilog-logs'
+          commit-message: 'Update logs'
+          user-email: 41898282+github-actions[bot]@users.noreply.github.com
+          target-branch: ${{ env.PUSH_BRANCH }}
+          create-target-branch-if-needed: true
+
+      - name: Post comment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: KeisukeYamashita/create-comment@v1
+        with:
+          check-only-first-line: "true"
+          unique: "true"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment: ${{ env.COMMENT_MSG }}
+
+      - name: Create summary
+        run:
+          echo "${{ env.COMMENT_MSG }}" >> $GITHUB_STEP_SUMMARY
 
   generate-tests-summary:
     name: Summary Generation

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -238,20 +238,23 @@ jobs:
           name: parsing-logs
           path: logs
 
+      - name: Set up common Ubuntu configuration
+        run: ./.github/scripts/set-up-common-ubuntu-configuration.sh
+
       - name: Install dependencies
         run: |
-          apt-get update -qq
-          apt install -y git
+          apt-get update -q
+          apt-get install -y git
 
       - name: Generate push branch name
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           PUSH_BRANCH=$branch
           if [[ ! -z "$PLUGINS_BRANCH_SPEC" ]]; then
-            PUSH_BRANCH="$PUSH_BRANCH+plugins+$PLUGINS_BRANCH_SPEC"
+            PUSH_BRANCH="${PUSH_BRANCH}+plugins+${PLUGINS_BRANCH_SPEC}"
           fi
           if [[ ! -z "$UHDM_TESTS_BRANCH_SPEC" ]]; then
-            PUSH_BRANCH="$PUSH_BRANCH+tests+$UHDM_TESTS_BRANCH_SPEC"
+            PUSH_BRANCH="${PUSH_BRANCH}+tests+${UHDM_TESTS_BRANCH_SPEC}"
           fi
           echo "PUSH_BRANCH=$PUSH_BRANCH" >> "$GITHUB_ENV"
           CURRENT_LOGS_SHA=$(git ls-remote https://github.com/${{ github.repository_owner }}/yosys-systemverilog-logs master | cut -d $'\t' -f1)
@@ -271,36 +274,41 @@ jobs:
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         run: |
-          .github/scripts/push_to_another_repository.sh ${{ github.repository_owner }} ${{ env.PUSH_BRANCH }} ${{ github.run_id }} logs
+          .github/scripts/push_to_logs_repository.sh "$GITHUB_REPOSITORY_OWNER" "$PUSH_BRANCH" "$GITHUB_RUN_ID" logs
 
       - name: Post comment
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v6
         with:
           script: |
-            const newComment = '${{ env.COMMENT_MSG }}';
             const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number
             });
-            const newFirstLine = newComment.split('\n')[0];
+            const newFirstLine = 'Logs difference between main branch:';
+            let commentUpdated = false;
             for (const comment of comments) {
               const oldFirstLine = comment.body.split('\n')[0];
               if (oldFirstLine == newFirstLine) {
-                github.rest.issues.deleteComment({
+                github.rest.issues.updateComment({
                   comment_id: comment.id,
                   owner: context.repo.owner,
-                  repo: context.repo.repo
+                  repo: context.repo.repo,
+                  body: '${{ env.COMMENT_MSG }}'
                 });
+                commentUpdated = true;
+                break;
               }
             }
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '${{ env.COMMENT_MSG }}'
-            });
+            if (!commentUpdated) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: '${{ env.COMMENT_MSG }}'
+              });
+            }
 
       - name: Create summary
         run:

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -295,7 +295,7 @@ jobs:
                   comment_id: comment.id,
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  body: '${{ env.COMMENT_MSG }}'
+                  body: process.env.COMMENT_MSG
                 });
                 commentUpdated = true;
                 break;
@@ -306,7 +306,7 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: '${{ env.COMMENT_MSG }}'
+                body: process.env.COMMENT_MSG
               });
             }
 

--- a/.github/workflows/parsing-tests.yml
+++ b/.github/workflows/parsing-tests.yml
@@ -223,16 +223,27 @@ jobs:
 
   push-logs:
     name: Generate AST diff
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:jammy
     needs:
       - tests-read-systemverilog
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
       - name: Download test results
         uses: /actions/download-artifact@v3
         with:
           name: parsing-logs
           path: logs
-      - name: Push branch
+
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt install -y git
+
+      - name: Generate push branch name
         run: |
           branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           PUSH_BRANCH=$branch
@@ -243,7 +254,8 @@ jobs:
             PUSH_BRANCH="$PUSH_BRANCH+tests+$UHDM_TESTS_BRANCH_SPEC"
           fi
           echo "PUSH_BRANCH=$PUSH_BRANCH" >> "$GITHUB_ENV"
-          COMMENT_MSG="Logs difference between main branch: https://github.com/${{ github.repository }}-logs/compare/$PUSH_BRANCH"
+          CURRENT_LOGS_SHA=$(git ls-remote https://github.com/${{ github.repository_owner }}/yosys-systemverilog-logs master | cut -d $'\t' -f1)
+          COMMENT_MSG="Logs difference between main branch:\nhttps://github.com/${{ github.repository }}-logs/compare/$CURRENT_LOGS_SHA..$PUSH_BRANCH"
           echo "COMMENT_MSG=$COMMENT_MSG" >> "$GITHUB_ENV"
           PUSH_LOGS=false
           # currently pushing logs when submodules are overriten using url is not supported
@@ -256,31 +268,43 @@ jobs:
           UHDM_TESTS_BRANCH_SPEC: ${{github.event.inputs.uhdm_tests_branch}}
 
       - name: Push logs
-        uses: cpina/github-action-push-to-another-repository@main
-        if: ${{ env.PUSH_LOGS == 'true' }}
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
-        with:
-          source-directory: 'logs'
-          destination-github-username: ${{ github.repository_owner }}
-          destination-repository-name: 'yosys-systemverilog-logs'
-          commit-message: 'Update logs'
-          user-email: 41898282+github-actions[bot]@users.noreply.github.com
-          target-branch: ${{ env.PUSH_BRANCH }}
-          create-target-branch-if-needed: true
+        run: |
+          .github/scripts/push_to_another_repository.sh ${{ github.repository_owner }} ${{ env.PUSH_BRANCH }} ${{ github.run_id }} logs
 
       - name: Post comment
         if: ${{ github.event_name == 'pull_request' }}
-        uses: KeisukeYamashita/create-comment@v1
+        uses: actions/github-script@v6
         with:
-          check-only-first-line: "true"
-          unique: "true"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          comment: ${{ env.COMMENT_MSG }}
+          script: |
+            const newComment = '${{ env.COMMENT_MSG }}';
+            const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number
+            });
+            const newFirstLine = newComment.split('\n')[0];
+            for (const comment of comments) {
+              const oldFirstLine = comment.body.split('\n')[0];
+              if (oldFirstLine == newFirstLine) {
+                github.rest.issues.deleteComment({
+                  comment_id: comment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo
+                });
+              }
+            }
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '${{ env.COMMENT_MSG }}'
+            });
 
       - name: Create summary
         run:
-          echo "${{ env.COMMENT_MSG }}" >> $GITHUB_STEP_SUMMARY
+          echo $'${{ env.COMMENT_MSG }}' >> $GITHUB_STEP_SUMMARY
 
   generate-tests-summary:
     name: Summary Generation


### PR DESCRIPTION
This PR adds new CI jobs that pushes AST to ``yosys-systemverilog-logs`` repository. This allows to easily view diff of AST between introduced changes.

URL with diff is posted as both github actions summary as well as PR comment (when event is pull_request).

Currently it only works when submodules are override using branches instead of whole url.