### PR TITLE
dependabot.yml: Update dependency name to be ignored

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     interval: "daily"
   open-pull-requests-limit: 30
   ignore:
-  - dependency-name: "bsg_micro_designs"
+  - dependency-name: "uhdm-tests/bsg_micro_designs/bsg_micro_designs"


### PR DESCRIPTION
During the work on PR #1732, we moved `bsg_micro_designs` submodule to `uhdm-tests/bsg_micro_designs` catalogue but didn't update the dependabot config file. Here's a followup.