### PR TITLE
Build blackparrot with SYNTHESIS=1

### DIFF
--- a/.github/workflows/large-designs.yml
+++ b/.github/workflows/large-designs.yml
@@ -543,8 +543,8 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: bp_unicore.edif
-          path: uhdm-tests/black-parrot/black-parrot/bp_top/syn/bp_unicore.edif
+          name: bp_e_bp_unicore_cfg.edif
+          path: UHDM-integration-tests/build/bp_e_bp_unicore_cfg.edif
 
       - name: Upload load graphs
         if: ${{ always() }}

--- a/uhdm-tests/black-parrot/Makefile.in
+++ b/uhdm-tests/black-parrot/Makefile.in
@@ -2,18 +2,24 @@ curr_dir:=$(dir $(lastword $(MAKEFILE_LIST)))
 ###################
 ### BLACKPARROT ###
 ###################
-VENV_BLACKPARROT_SYNTH = ${root_dir}/venv-blackparrot-synth
 BLACKPARROT = ${curr_dir}/black-parrot
+BLACKPARROT_PATCHES_DIR = ${curr_dir}/black-parrot-patches/black-parrot/
+BLACKPARROT_BASEJUMP = ${BLACKPARROT}/external/basejump_stl/
+BLACKPARROT_BASEJUMP_PATCHES_DIR = ${curr_dir}/black-parrot-patches/basejump_stl
+BLACKPARROT_CFG ?= e_bp_unicore_cfg
+BLACKPARROT_UHDM = ${root_dir}/build/surelog/bp_tethered.${BLACKPARROT_CFG}.none.parse/out/slpp_unit/surelog.uhdm
 
-${VENV_BLACKPARROT_SYNTH}:
-	virtualenv ${VENV_BLACKPARROT_SYNTH}
-	(. ${VENV_BLACKPARROT_SYNTH}/bin/activate)
+${BLACKPARROT}/.gitpatch:
+	cd ${BLACKPARROT}/ && git apply ${BLACKPARROT_PATCHES_DIR}/*.patch && touch $@
 
-uhdm/yosys/synth-blackparrot-build: clean-build | ${VENV_BLACKPARROT_SYNTH}
+${BLACKPARROT_UHDM}: clean-build | ${BLACKPARROT}/.gitpatch
 	(export PATH=${root_dir}/../image/bin:${PATH} && \
-		. ${VENV_BLACKPARROT_SYNTH}/bin/activate && \
-		cd ${BLACKPARROT}/bp_top/syn/ && SURELOG_OPTS=-synth $(MAKE) parse.surelog CFG=e_bp_unicore_cfg && \
+		cd ${BLACKPARROT}/bp_top/syn/ && SURELOG_OPTS="-synth -DSYNTHESIS=1" $(MAKE) parse.surelog CFG=${BLACKPARROT_CFG} RESULTS_PATH=${root_dir}/build)
+
+uhdm/yosys/synth-blackparrot-build: | ${BLACKPARROT_UHDM}
+	(export PATH=${root_dir}/../image/bin:${PATH} && \
+		cd ${root_dir}/build && \
 		yosys -p "plugin -i systemverilog" \
-		      -p "read_uhdm ./results/surelog/bp_tethered.e_bp_unicore_cfg.none.parse/out/slpp_unit/surelog.uhdm" \
-		      -p "synth_xilinx -iopad -family xc7" \
-		      -p "write_edif bp_unicore.edif")
+                      -p "read_uhdm ${BLACKPARROT_UHDM}" \
+                      -p "synth_xilinx -iopad -family xc7" \
+                      -p "write_edif bp_${BLACKPARROT_CFG}.edif")

--- a/uhdm-tests/black-parrot/black-parrot-patches/black-parrot/0001-use-synth-filelist.patch
+++ b/uhdm-tests/black-parrot/black-parrot-patches/black-parrot/0001-use-synth-filelist.patch
@@ -1,0 +1,14 @@
+diff --git a/bp_top/syn/flist.vcs b/bp_top/syn/flist.vcs
+index f889ef17..a268f121 100644
+--- a/bp_top/syn/flist.vcs
++++ b/bp_top/syn/flist.vcs
+@@ -84,8 +84,7 @@ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync_synth.v
+ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_sync.v
+ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1r1w_synth.v
+ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync.v
+-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+-$BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_bit_synth.v
++$BASEJUMP_STL_DIR/hard/ultrascale_plus/bsg_mem/bsg_mem_1rw_sync_mask_write_bit.v
+ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_byte.v
+ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_mask_write_byte_synth.v
+ $BASEJUMP_STL_DIR/bsg_mem/bsg_mem_1rw_sync_synth.v


### PR DESCRIPTION
This PR adds ``-DSYNTHESIS=1`` to surelog command to make sure synthesis path is used in the code.

This RP also replaces on of the files for it's synthesis compatible version: https://github.com/black-parrot/black-parrot/blob/4ae2e5af2bdf1860581c15826a12eab59a381eb2/bp_common/syn/tcl/vivado_synth.tcl#L26