### PR TITLE
CI: Use latest stable Debian instead of SID.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -395,7 +395,7 @@ jobs:
   install-plugin:
     name: Release Package Installation Test
     runs-on: [self-hosted, Linux, X64]
-    container: debian:sid
+    container: debian:latest
     needs: release
     env:
       DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/tuttest.yml
+++ b/.github/workflows/tuttest.yml
@@ -92,7 +92,7 @@ jobs:
 
   test-plugin-debian:
     runs-on: [self-hosted, Linux, X64]
-    container: debian:sid
+    container: debian:latest
     env:
       DEBIAN_FRONTEND: noninteractive
       PIPX_BIN_DIR: /usr/local/bin


### PR DESCRIPTION
SID is unstable, which means it gets untested packages. Recently yosys package has appeared in SID even though it failed Debian's automatic regression tests.
Let's go with a stable release, like we do with Ubuntu.